### PR TITLE
Move position relative to control instead of the container

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -514,7 +514,7 @@ const MentionsInput = React.createClass({
       this._scrollParent = scrollParent;
       this._scrollParent.addEventListener('scroll', this.handleParentScroll);
     }
-  }
+  },
 
   setSelection: function(selectionStart, selectionEnd) {
     if(selectionStart === null || selectionEnd === null) return;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -484,8 +484,7 @@ const MentionsInput = React.createClass({
 
   componentDidMount: function() {
     this.updateSuggestionsPosition();
-    this._scrollParent = _getScrollParent(this.refs.container);
-    this._scrollParent.addEventListener('scroll', this.handleParentScroll);
+    this.addScrollListener();
   },
 
   componentDidUpdate: function() {
@@ -494,8 +493,7 @@ const MentionsInput = React.createClass({
     // In case the parent scroll container changes
     if (newScrollParent !== this._scrollParent) {
       this._scrollParent.removeEventListener('scroll', this.handleParentScroll);
-      this._scrollParent = newScrollParent;
-      this._scrollParent.addEventListener('scroll', this.handleParentScroll);
+      this.addScrollListener();
     }
 
     // maintain selection in case a mention is added/removed causing
@@ -509,6 +507,14 @@ const MentionsInput = React.createClass({
   componentWillUnmount: function() {
     this._scrollParent.removeEventListener('scroll', this.handleParentScroll);
   },
+
+  addScrollListener: function () {
+    const scrollParent = _getScrollParent(this.refs.container);
+    if (scrollParent) {
+      this._scrollParent = scrollParent;
+      this._scrollParent.addEventListener('scroll', this.handleParentScroll);
+    }
+  }
 
   setSelection: function(selectionStart, selectionEnd) {
     if(selectionStart === null || selectionEnd === null) return;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -493,6 +493,7 @@ const MentionsInput = React.createClass({
     // In case the parent scroll container changes
     if (newScrollParent !== this._scrollParent) {
       this._scrollParent.removeEventListener('scroll', this.handleParentScroll);
+      this._scrollParent = null;
       this.addScrollListener();
     }
 
@@ -505,6 +506,8 @@ const MentionsInput = React.createClass({
   },
 
   componentWillUnmount: function() {
+    if(this._scrollParent === null) return;
+
     this._scrollParent.removeEventListener('scroll', this.handleParentScroll);
   },
 
@@ -657,8 +660,8 @@ const MentionsInput = React.createClass({
   },
 
   _queryId: 0,
-  _ticking: false
-
+  _ticking: false,
+  _scrollParent: null
 
 });
 


### PR DESCRIPTION
Added a couple of improvements* on the SuggestionsOverlay position:
- `position: relative` was moved to `control` rather than the `container`. This caused  SuggestionOverlay to not overflow the user's container. The issue manifests when you use a `<Mention>` in an scrollable element like a popover. The problem with this approach is that the SuggestionOverlay is positioned relative to an external scrollable element that we have to listen in order to determine the right position at any time
- `this.state.suggestionsPosition` has less priority than `style`, this will allow a user to override the suggestions position, maybe the best solution is to expose a prop to calculate the `suggestionPosition` but I think having a workaround for now is better than nothing.

* according to me :)