### PR TITLE
Fix breaking React invariant error on production builds when using singleLine true

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -53,33 +53,35 @@ const KEY = { TAB: 9, RETURN: 13, ESC: 27, UP: 38, DOWN: 40 }
 
 let isComposing = false
 
+const propTypes = {
+  /**
+   * If set to `true` a regular text input element will be rendered
+   * instead of a textarea
+   */
+  singleLine: PropTypes.bool,
+
+  /**
+   * If set to `true` spaces will not interrupt matching suggestions
+   */
+  allowSpaceInQuery: PropTypes.bool,
+
+  markup: PropTypes.string,
+  value: PropTypes.string,
+
+  displayTransform: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onSelect: PropTypes.func,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element),
+  ]).isRequired,
+}
+
 class MentionsInput extends React.Component {
-  static propTypes = {
-    /**
-     * If set to `true` a regular text input element will be rendered
-     * instead of a textarea
-     */
-    singleLine: PropTypes.bool,
-
-    /**
-     * If set to `true` spaces will not interrupt matching suggestions
-     */
-    allowSpaceInQuery: PropTypes.bool,
-
-    markup: PropTypes.string,
-    value: PropTypes.string,
-
-    displayTransform: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    onSelect: PropTypes.func,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-
-    children: PropTypes.oneOfType([
-      PropTypes.element,
-      PropTypes.arrayOf(PropTypes.element),
-    ]).isRequired,
-  }
+  static propTypes = propTypes
 
   static defaultProps = {
     markup: '@[__display__](__id__)',
@@ -122,7 +124,7 @@ class MentionsInput extends React.Component {
     let { readOnly, disabled, style } = this.props
 
     // pass all props that we don't use through to the input control
-    let props = omit(this.props, 'style', keys(MentionsInput.propTypes))
+    let props = omit(this.props, 'style', keys(propTypes))
 
     return {
       ...props,


### PR DESCRIPTION
We ran into a very difficult to track bug that occurred only on production builds of our app.
React threw an invariant error which causes React rendering to break entirely (https://reactjs.org/docs/error-decoder.html?invariant=137&args[]=input&args[]=)

After digging deeper into our code, we found out that a `<MentionsInput />` component from `react-mentions` was the cause of this error. This error only occurred when `singleLine` was true, which makes sense because the `invariant` error is about `input` elements.

Digging deeper into the `react-mentions` code led us to [this line](https://github.com/signavio/react-mentions/blob/master/src/MentionsInput.js#L125): 
```
let props = omit(this.props, 'style', keys(MentionsInput.propTypes))
```

Omitting the props with the `propType` keys does not work on production builds. I think because there's a babel plugin that optimizes the propTypes. This is the output from the production build: 

```
MentionsInput.propTypes = process.env.NODE_ENV !== "production" ? propTypes : {};
```

Because of this, `children` (the `Mention` component) did not get omitted from the props to be passed to `<input />` and caused React to throw an invariant error.