### PR TITLE
Avoid suggestions ID clashing for different mention types

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -11,7 +11,8 @@ class Demo extends Component {
         <p>
           <span role="img" aria-labelledby="yay!">
             🙌
-          </span>&nbsp; brought to you by Signavio, docs and code on Github:{' '}
+          </span>
+          &nbsp; brought to you by Signavio, docs and code on Github:{' '}
           <a href="https://github.com/signavio/react-mentions">
             https://github.com/signavio/react-mentions
           </a>{' '}

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -81,7 +81,7 @@ class Highlighter extends Component {
       displayTransform,
       style,
       inputStyle,
-      regex
+      regex,
     } = this.props
 
     // If there's a caret (i.e. no range selection), map the caret position into the marked up value

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -1,10 +1,10 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { defaultStyle } from "substyle";
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { defaultStyle } from 'substyle'
 
-import { countSuggestions, getSuggestions } from "./utils";
-import Suggestion from "./Suggestion";
-import LoadingIndicator from "./LoadingIndicator";
+import { countSuggestions, getSuggestions } from './utils'
+import Suggestion from './Suggestion'
+import LoadingIndicator from './LoadingIndicator'
 
 class SuggestionsOverlay extends Component {
   static propTypes = {
@@ -12,13 +12,13 @@ class SuggestionsOverlay extends Component {
     focusIndex: PropTypes.number,
     scrollFocusedIntoView: PropTypes.bool,
     isLoading: PropTypes.bool,
-    onSelect: PropTypes.func
-  };
+    onSelect: PropTypes.func,
+  }
 
   static defaultProps = {
     suggestions: {},
-    onSelect: () => null
-  };
+    onSelect: () => null,
+  }
 
   componentDidUpdate() {
     if (
@@ -26,46 +26,46 @@ class SuggestionsOverlay extends Component {
       this.suggestionsRef.offsetHeight >= this.suggestionsRef.scrollHeight ||
       !this.props.scrollFocusedIntoView
     ) {
-      return;
+      return
     }
 
-    const scrollTop = this.suggestionsRef.scrollTop;
+    const scrollTop = this.suggestionsRef.scrollTop
     let { top, bottom } = this.suggestionsRef.children[
       this.props.focusIndex
-    ].getBoundingClientRect();
-    const { top: topContainer } = this.suggestionsRef.getBoundingClientRect();
-    top = top - topContainer + scrollTop;
-    bottom = bottom - topContainer + scrollTop;
+    ].getBoundingClientRect()
+    const { top: topContainer } = this.suggestionsRef.getBoundingClientRect()
+    top = top - topContainer + scrollTop
+    bottom = bottom - topContainer + scrollTop
 
     if (top < scrollTop) {
-      this.suggestionsRef.scrollTop = top;
+      this.suggestionsRef.scrollTop = top
     } else if (bottom > this.suggestionsRef.offsetHeight) {
-      this.suggestionsRef.scrollTop = bottom - this.suggestionsRef.offsetHeight;
+      this.suggestionsRef.scrollTop = bottom - this.suggestionsRef.offsetHeight
     }
   }
 
   render() {
-    const { suggestions, isLoading, style, onMouseDown } = this.props;
+    const { suggestions, isLoading, style, onMouseDown } = this.props
 
     // do not show suggestions until there is some data
     if (countSuggestions(suggestions) === 0 && !isLoading) {
-      return null;
+      return null
     }
 
     return (
       <div {...style} onMouseDown={onMouseDown}>
         <ul
           ref={el => {
-            this.suggestionsRef = el;
+            this.suggestionsRef = el
           }}
-          {...style("list")}
+          {...style('list')}
         >
           {this.renderSuggestions()}
         </ul>
 
         {this.renderLoadingIndicator()}
       </div>
-    );
+    )
   }
 
   renderSuggestions() {
@@ -75,23 +75,23 @@ class SuggestionsOverlay extends Component {
 
         ...suggestions.map((suggestion, index) =>
           this.renderSuggestion(suggestion, descriptor, result.length + index)
-        )
+        ),
       ],
       []
-    );
+    )
   }
 
   renderSuggestion(suggestion, descriptor, index) {
-    let id = this.getID(suggestion);
-    let isFocused = index === this.props.focusIndex;
+    let id = this.getID(suggestion)
+    let isFocused = index === this.props.focusIndex
 
-    let { mentionDescriptor, query } = descriptor;
+    let { mentionDescriptor, query } = descriptor
 
-    const type = mentionDescriptor.props.type;
+    const type = mentionDescriptor.props.type
 
     return (
       <Suggestion
-        style={this.props.style("item")}
+        style={this.props.style('item')}
         key={`${type}-${id}`}
         id={id}
         query={query}
@@ -102,40 +102,40 @@ class SuggestionsOverlay extends Component {
         onClick={() => this.select(suggestion, descriptor)}
         onMouseEnter={() => this.handleMouseEnter(index)}
       />
-    );
+    )
   }
 
   getID(suggestion) {
     if (suggestion instanceof String) {
-      return suggestion;
+      return suggestion
     }
 
-    return suggestion.id;
+    return suggestion.id
   }
 
   renderLoadingIndicator() {
     if (!this.props.isLoading) {
-      return;
+      return
     }
 
-    return <LoadingIndicator {...this.props.style("loadingIndicator")} />;
+    return <LoadingIndicator {...this.props.style('loadingIndicator')} />
   }
 
   handleMouseEnter(index, ev) {
     if (this.props.onMouseEnter) {
-      this.props.onMouseEnter(index);
+      this.props.onMouseEnter(index)
     }
   }
 
   select(suggestion, descriptor) {
-    this.props.onSelect(suggestion, descriptor);
+    this.props.onSelect(suggestion, descriptor)
   }
 }
 
 const styled = defaultStyle(({ position }) => ({
-  position: "absolute",
+  position: 'absolute',
   zIndex: 1,
-  backgroundColor: "white",
+  backgroundColor: 'white',
   marginTop: 14,
   minWidth: 100,
   ...position,
@@ -143,8 +143,8 @@ const styled = defaultStyle(({ position }) => ({
   list: {
     margin: 0,
     padding: 0,
-    listStyleType: "none"
-  }
-}));
+    listStyleType: 'none',
+  },
+}))
 
-export default styled(SuggestionsOverlay);
+export default styled(SuggestionsOverlay)

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import { defaultStyle } from 'substyle'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { defaultStyle } from "substyle";
 
-import { countSuggestions, getSuggestions } from './utils'
-import Suggestion from './Suggestion'
-import LoadingIndicator from './LoadingIndicator'
+import { countSuggestions, getSuggestions } from "./utils";
+import Suggestion from "./Suggestion";
+import LoadingIndicator from "./LoadingIndicator";
 
 class SuggestionsOverlay extends Component {
   static propTypes = {
@@ -12,13 +12,13 @@ class SuggestionsOverlay extends Component {
     focusIndex: PropTypes.number,
     scrollFocusedIntoView: PropTypes.bool,
     isLoading: PropTypes.bool,
-    onSelect: PropTypes.func,
-  }
+    onSelect: PropTypes.func
+  };
 
   static defaultProps = {
     suggestions: {},
-    onSelect: () => null,
-  }
+    onSelect: () => null
+  };
 
   componentDidUpdate() {
     if (
@@ -26,46 +26,46 @@ class SuggestionsOverlay extends Component {
       this.suggestionsRef.offsetHeight >= this.suggestionsRef.scrollHeight ||
       !this.props.scrollFocusedIntoView
     ) {
-      return
+      return;
     }
 
-    const scrollTop = this.suggestionsRef.scrollTop
+    const scrollTop = this.suggestionsRef.scrollTop;
     let { top, bottom } = this.suggestionsRef.children[
       this.props.focusIndex
-    ].getBoundingClientRect()
-    const { top: topContainer } = this.suggestionsRef.getBoundingClientRect()
-    top = top - topContainer + scrollTop
-    bottom = bottom - topContainer + scrollTop
+    ].getBoundingClientRect();
+    const { top: topContainer } = this.suggestionsRef.getBoundingClientRect();
+    top = top - topContainer + scrollTop;
+    bottom = bottom - topContainer + scrollTop;
 
     if (top < scrollTop) {
-      this.suggestionsRef.scrollTop = top
+      this.suggestionsRef.scrollTop = top;
     } else if (bottom > this.suggestionsRef.offsetHeight) {
-      this.suggestionsRef.scrollTop = bottom - this.suggestionsRef.offsetHeight
+      this.suggestionsRef.scrollTop = bottom - this.suggestionsRef.offsetHeight;
     }
   }
 
   render() {
-    const { suggestions, isLoading, style, onMouseDown } = this.props
+    const { suggestions, isLoading, style, onMouseDown } = this.props;
 
     // do not show suggestions until there is some data
     if (countSuggestions(suggestions) === 0 && !isLoading) {
-      return null
+      return null;
     }
 
     return (
       <div {...style} onMouseDown={onMouseDown}>
         <ul
           ref={el => {
-            this.suggestionsRef = el
+            this.suggestionsRef = el;
           }}
-          {...style('list')}
+          {...style("list")}
         >
           {this.renderSuggestions()}
         </ul>
 
         {this.renderLoadingIndicator()}
       </div>
-    )
+    );
   }
 
   renderSuggestions() {
@@ -75,22 +75,24 @@ class SuggestionsOverlay extends Component {
 
         ...suggestions.map((suggestion, index) =>
           this.renderSuggestion(suggestion, descriptor, result.length + index)
-        ),
+        )
       ],
       []
-    )
+    );
   }
 
   renderSuggestion(suggestion, descriptor, index) {
-    let id = this.getID(suggestion)
-    let isFocused = index === this.props.focusIndex
+    let id = this.getID(suggestion);
+    let isFocused = index === this.props.focusIndex;
 
-    let { mentionDescriptor, query } = descriptor
+    let { mentionDescriptor, query } = descriptor;
+
+    const type = mentionDescriptor.props.type;
 
     return (
       <Suggestion
-        style={this.props.style('item')}
-        key={id}
+        style={this.props.style("item")}
+        key={`${type}-${id}`}
         id={id}
         query={query}
         index={index}
@@ -100,40 +102,40 @@ class SuggestionsOverlay extends Component {
         onClick={() => this.select(suggestion, descriptor)}
         onMouseEnter={() => this.handleMouseEnter(index)}
       />
-    )
+    );
   }
 
   getID(suggestion) {
     if (suggestion instanceof String) {
-      return suggestion
+      return suggestion;
     }
 
-    return suggestion.id
+    return suggestion.id;
   }
 
   renderLoadingIndicator() {
     if (!this.props.isLoading) {
-      return
+      return;
     }
 
-    return <LoadingIndicator {...this.props.style('loadingIndicator')} />
+    return <LoadingIndicator {...this.props.style("loadingIndicator")} />;
   }
 
   handleMouseEnter(index, ev) {
     if (this.props.onMouseEnter) {
-      this.props.onMouseEnter(index)
+      this.props.onMouseEnter(index);
     }
   }
 
   select(suggestion, descriptor) {
-    this.props.onSelect(suggestion, descriptor)
+    this.props.onSelect(suggestion, descriptor);
   }
 }
 
 const styled = defaultStyle(({ position }) => ({
-  position: 'absolute',
+  position: "absolute",
   zIndex: 1,
-  backgroundColor: 'white',
+  backgroundColor: "white",
   marginTop: 14,
   minWidth: 100,
   ...position,
@@ -141,8 +143,8 @@ const styled = defaultStyle(({ position }) => ({
   list: {
     margin: 0,
     padding: 0,
-    listStyleType: 'none',
-  },
-}))
+    listStyleType: "none"
+  }
+}));
 
-export default styled(SuggestionsOverlay)
+export default styled(SuggestionsOverlay);

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,12 +15,11 @@ const numericComparator = function(a, b) {
 
 export const escapeRegex = str => str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
 
-
 const countCapturingGroups = regex => {
-  return (new RegExp(regex.toString() + '|')).exec('').length - 1
+  return new RegExp(regex.toString() + '|').exec('').length - 1
 }
 
-const markupToRegex = (markup) => {
+const markupToRegex = markup => {
   let markupPattern = escapeRegex(markup)
   markupPattern = markupPattern.replace(PLACEHOLDERS.display, '(.+?)')
   markupPattern = markupPattern.replace(PLACEHOLDERS.id, '(.+?)')
@@ -79,16 +78,15 @@ export const getPositionOfCapturingGroup = (markup, parameterName, regex) => {
   if (indexDisplay === null) indexDisplay = indexId
   if (indexId === null) indexId = indexDisplay
 
-
-  if(regex && countCapturingGroups(regex) === 0) {
+  if (regex && countCapturingGroups(regex) === 0) {
     // custom regex does not use any capturing groups, so use the full match for ID and display
-    return parameterName === "type" ? null : 0;
+    return parameterName === 'type' ? null : 0
   }
 
-  if(parameterName === "id") return sortedIndices.indexOf(indexId);
-  if(parameterName === "display") return sortedIndices.indexOf(indexDisplay);
-  if(parameterName === "type") return indexType === null ? null : sortedIndices.indexOf(indexType);
-
+  if (parameterName === 'id') return sortedIndices.indexOf(indexId)
+  if (parameterName === 'display') return sortedIndices.indexOf(indexDisplay)
+  if (parameterName === 'type')
+    return indexType === null ? null : sortedIndices.indexOf(indexType)
 }
 
 // Finds all occurences of the markup in the value and iterates the plain text sub strings
@@ -345,7 +343,12 @@ export const applyChangeToValue = (
 
   if (!willRemoveMention) {
     // test for auto-completion changes
-    let controlPlainTextValue = getPlainText(newValue, markup, displayTransform, regex)
+    let controlPlainTextValue = getPlainText(
+      newValue,
+      markup,
+      displayTransform,
+      regex
+    )
     if (controlPlainTextValue !== plainTextValue) {
       // some auto-correction is going on
 


### PR DESCRIPTION
Fixes #ABC

What did you change (functionally and technically)?
Simple edit to avoid having suggestions with the same react key, appending mention type before the id in the SuggestionsOverlay rendering loop.

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code?
No
* Does the code comply to our code conventions?
Yes
* Does the PR resolve the whole issue?
It does

**Additional review hints** (remove this list before you submit the PR)
* Besides the code review, what should the reviewer test?
* Are there any edge cases?
* Do you have any test files or test set-up?
* Could your changes cause side effects elsewhere in the code base?
Nope
