### PR TITLE
Guard for mentions suggestions list clipped by bottom edge of window

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -533,13 +533,13 @@ class MentionsInput extends React.Component {
 
       // guard for mentions suggestions list clipped by bottom edge of window
       const tooltipBottom =
-        _this3.containerRef.getBoundingClientRect().top +
+        this.containerRef.getBoundingClientRect().top +
         caretPosition.top +
         suggestions.offsetHeight;
         const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
       if (tooltipBottom > viewportHeight) {
-        position.bottom = _this3.containerRef.offsetHeight - caretPosition.top;
+        position.bottom = this.containerRef.offsetHeight - caretPosition.top;
       } else {
         position.top = caretPosition.top - highlighter.scrollTop;
       }

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -530,7 +530,19 @@ class MentionsInput extends React.Component {
       } else {
         position.left = left
       }
-      position.top = caretPosition.top - highlighter.scrollTop
+
+      // guard for mentions suggestions list clipped by bottom edge of window
+      const tooltipBottom =
+        _this3.containerRef.getBoundingClientRect().top +
+        caretPosition.top +
+        suggestions.offsetHeight;
+        const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+
+      if (tooltipBottom > viewportHeight) {
+        position.bottom = _this3.containerRef.offsetHeight - caretPosition.top;
+      } else {
+        position.top = caretPosition.top - highlighter.scrollTop;
+      }
     }
 
     if (isEqual(position, this.state.suggestionsPosition)) {

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -525,18 +525,18 @@ class MentionsInput extends React.Component {
     } else {
       let left = caretPosition.left - highlighter.scrollLeft
       // guard for mentions suggestions list clipped by right edge of window
-      if (left + suggestions.offsetWidth > this.containerRef.offsetWidth) {
+      if (this.containerRef && (left + suggestions.offsetWidth > this.containerRef.offsetWidth)) {
         position.right = 0
       } else {
         position.left = left
       }
 
       // guard for mentions suggestions list clipped by bottom edge of window
-      const tooltipBottom =
+      const tooltipBottom = this.containerRef ?
         this.containerRef.getBoundingClientRect().top +
         caretPosition.top +
-        suggestions.offsetHeight;
-        const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+        suggestions.offsetHeight : 0;
+      const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
       if (tooltipBottom > viewportHeight) {
         position.bottom = this.containerRef.offsetHeight - caretPosition.top;


### PR DESCRIPTION
When the mentions popup is near the bottom of the screen it will be moved up so it doesn't get cut.
This correction will only be applied when the property suggestionsPortalHost is not being used.

