### PR TITLE
Fix cursor jumping on android

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -368,14 +368,14 @@ class MentionsInput extends React.Component {
 
   // Handle input element's select event
   handleSelect = ev => {
-    // do nothing while a IME composition session is active
-    if (isComposing) return
-
     // keep track of selection range / caret position
     this.setState({
       selectionStart: ev.target.selectionStart,
       selectionEnd: ev.target.selectionEnd,
     })
+
+    // do nothing while a IME composition session is active
+    if (isComposing) return
 
     // refresh suggestions queries
     const el = this.inputRef


### PR DESCRIPTION
Fixes #274

What did you change (functionally and technically)?
This makes it so that the selectionStart and selectionEnd are set even if it is being selected in the "composition" mode in android. This was causing the cursor jumping issue described in https://github.com/signavio/react-mentions/issues/274 because if you selected a point in the text then selected some point after it (eg. the next line), it would double up the text because it thought the cursor was still at the first point.
