### PR TITLE
onRemove functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | allowSpaceInQuery     | boolean                                                 | false                      | Keep suggestions open even if the user separates keywords with spaces.                 |
 | suggestionsPortalHost | DOM Element                                             | undefined                  | Render suggestions into the DOM in the supplied host element.                          |
 | inputRef              | React ref                                               | undefined                  | Accepts a React ref to forward to the underlying input element                         |
-| onRemove              | function (Array.<id, display>)                          | `null`                     | Callback invoked when a mention has been removed (optional)                            |
+| onRemove              | function (Array.Object.<id, display>})                  | `null`                     | Callback invoked when a mention has been removed (optional)                            |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | allowSpaceInQuery     | boolean                                                 | false                      | Keep suggestions open even if the user separates keywords with spaces.                 |
 | suggestionsPortalHost | DOM Element                                             | undefined                  | Render suggestions into the DOM in the supplied host element.                          |
 | inputRef              | React ref                                               | undefined                  | Accepts a React ref to forward to the underlying input element                         |
+| onRemove              | function (Array.<id, display>)                          | `null`                     | Callback invoked when a mention has been removed (optional)                            |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/demo/src/examples/MultipleTrigger.js
+++ b/demo/src/examples/MultipleTrigger.js
@@ -11,7 +11,7 @@ import defaultMentionStyle from './defaultMentionStyle'
 // and second/inner capture group to extract search string from the match
 const emailRegex = /(([^\s@]+@[^\s@]+\.[^\s@]+))$/
 
-function MultipleTriggers({ value, data, onChange, onAdd }) {
+function MultipleTriggers({ value, data, onChange, onAdd, onRemove }) {
   return (
     <div className="multiple-triggers">
       <h3>Multiple trigger patterns</h3>
@@ -23,6 +23,7 @@ function MultipleTriggers({ value, data, onChange, onAdd }) {
         style={defaultStyle}
         markup="@[__display__](__type__:__id__)"
         placeholder={"Mention people using '@'"}
+        onRemove={onRemove}
       >
         <Mention
           type="user"

--- a/demo/src/examples/higher-order/provideExampleValue.js
+++ b/demo/src/examples/higher-order/provideExampleValue.js
@@ -6,6 +6,7 @@ export default function provideExampleValue(value) {
     withHandlers({
       onChange: ({ setValue }) => (ev, newValue) => setValue(newValue),
       onAdd: () => (...args) => console.log('added a new mention', ...args),
+      onRemove: () => (...args) => console.log('removed mention(s)', ...args),
     })
   )
 }

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -112,9 +112,7 @@ class MentionsInput extends React.Component {
     onKeyDown: () => null,
     onSelect: () => null,
     onBlur: () => null,
-    onRemove: function(mentions) {
-      return null
-    },
+    onRemove: (mentions) => null,
   }
 
   constructor(props) {
@@ -365,18 +363,18 @@ class MentionsInput extends React.Component {
 
     // Check for removed mentions
     var removed = this.state.mentions.filter(mention => {
-      return !Boolean(mentions.find(newMention => newMention.id === mention.id && newMention.display == mention.display))
+      return !Boolean(mentions.find(newMention => newMention.id === mention.id && newMention.display === mention.display))
     })
 
     // Call onRemove
-    if (removed.length > 0) {
+    if (removed.length > 0 && this.props.onRemove) {
       if (this.props.onRemove) {
         this.props.onRemove(removed)
       }
     }
 
     // Update state with removed mentions
-    this.setState({ mentions: mentions })
+    this.setState({ mentions })
 
     // Propagate change
     // let handleChange = this.getOnChange(this.props) || emptyFunction;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -87,6 +87,7 @@ const propTypes = {
   onSelect: PropTypes.func,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onRemove: PropTypes.func,
   suggestionsPortalHost: typeof Element === 'undefined' ? PropTypes.any : PropTypes.PropTypes.instanceOf(Element),
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
@@ -111,6 +112,9 @@ class MentionsInput extends React.Component {
     onKeyDown: () => null,
     onSelect: () => null,
     onBlur: () => null,
+    onRemove: function(mentions) {
+      return null
+    },
   }
 
   constructor(props) {
@@ -127,6 +131,7 @@ class MentionsInput extends React.Component {
 
       caretPosition: null,
       suggestionsPosition: null,
+      mentions: [],
     }
   }
 
@@ -357,6 +362,21 @@ class MentionsInput extends React.Component {
     })
 
     let mentions = getMentions(newValue, markup, displayTransform, regex)
+
+    // Check for removed mentions
+    var removed = this.state.mentions.filter(mention => {
+      return !Boolean(mentions.find(newMention => newMention.id === mention.id && newMention.display == mention.display))
+    })
+
+    // Call onRemove
+    if (removed.length > 0) {
+      if (this.props.onRemove) {
+        this.props.onRemove(removed)
+      }
+    }
+
+    // Update state with removed mentions
+    this.setState({ mentions: mentions })
 
     // Propagate change
     // let handleChange = this.getOnChange(this.props) || emptyFunction;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -358,7 +358,7 @@ class MentionsInput extends React.Component {
       setSelectionAfterMentionChange: setSelectionAfterMentionChange,
     })
 
-    let prevMentions = getMentions(value, markup, displayTransform, regex)
+    let prevMentions = getMentions(this.props.value, markup, displayTransform, regex)
     let mentions = getMentions(newValue, markup, displayTransform, regex)
 
     // Check for removed mentions

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -129,7 +129,6 @@ class MentionsInput extends React.Component {
 
       caretPosition: null,
       suggestionsPosition: null,
-      mentions: [],
     }
   }
 
@@ -359,22 +358,20 @@ class MentionsInput extends React.Component {
       setSelectionAfterMentionChange: setSelectionAfterMentionChange,
     })
 
+    let prevMentions = getMentions(value, markup, displayTransform, regex)
     let mentions = getMentions(newValue, markup, displayTransform, regex)
 
     // Check for removed mentions
-    var removed = this.state.mentions.filter(mention => {
+    var removed = prevMentions.filter(mention => {
       return !Boolean(mentions.find(newMention => newMention.id === mention.id && newMention.display === mention.display))
+    }).map(mention => {
+      return {id: mention.id, display: mention.display}
     })
 
     // Call onRemove
     if (removed.length > 0 && this.props.onRemove) {
-      if (this.props.onRemove) {
-        this.props.onRemove(removed)
-      }
+      this.props.onRemove(removed)
     }
-
-    // Update state with removed mentions
-    this.setState({ mentions })
 
     // Propagate change
     // let handleChange = this.getOnChange(this.props) || emptyFunction;

--- a/test/MentionsInput.spec.js
+++ b/test/MentionsInput.spec.js
@@ -212,4 +212,35 @@ describe('MentionsInput', () => {
       expect(result).toEqual('/(?:^|\\s)(trigger([^trigger]*))$/')
     })
   })
+
+  it('should call onRemove on erasing a mention', () => {
+    const removed = (mentions) => {
+      expect(mentions[0].id).toBe('a')
+      expect(mentions[0].display).toBe('A')
+    }
+
+    const wrapper = mount(
+      <MentionsInput value="@[A](testchars:a)" markup="@[__display__](__type__:__id__)" onRemove={removed}>
+        <Mention trigger="@" type="testentries" data={data} />
+        <Mention
+          trigger="@"
+          type="testchars"
+          data={[{ id: 'a', value: 'A' }, { id: 'b', value: 'B' }]}
+        />
+      </MentionsInput>,
+      {
+        attachTo: host,
+      }
+    )
+
+    wrapper.find('textarea').getDOMNode().focus()
+    wrapper.find('textarea').simulate('select', {
+      target: { selectionStart: 0, selectionEnd: 0 },
+    })
+    wrapper.find('textarea').getDOMNode().value = ''
+    wrapper.find('textarea').simulate('change', {
+      target: wrapper.find('textarea').getDOMNode()
+    })
+  })
+
 })

--- a/test/MentionsInput.spec.js
+++ b/test/MentionsInput.spec.js
@@ -214,10 +214,7 @@ describe('MentionsInput', () => {
   })
 
   it('should call onRemove on erasing a mention', () => {
-    const removed = (mentions) => {
-      expect(mentions[0].id).toBe('a')
-      expect(mentions[0].display).toBe('A')
-    }
+    const removed = createSpy()
 
     const wrapper = mount(
       <MentionsInput value="@[A](testchars:a)" markup="@[__display__](__type__:__id__)" onRemove={removed}>
@@ -241,6 +238,6 @@ describe('MentionsInput', () => {
     wrapper.find('textarea').simulate('change', {
       target: wrapper.find('textarea').getDOMNode()
     })
+    expect(removed).toHaveBeenCalledWith([{id: 'a', display: 'A'}])
   })
-
 })


### PR DESCRIPTION
Fixes #92 

What did you change (functionally and technically)?
I implemented an onRemove prop that will take a function on the MentionsInput component, and as mentions are removed it will pass back an array of mentions that have been removed. 

Edge Case:
At this moment if a mention is added without adding or removing any additional characters followed by deleting it with the backspace button, onRemove isn't called as onChange isn't called in the component. This can be worked around by using the appendSpaceOnAdd prop. 