### PR TITLE
Allow ID field in Mention data to be 0

### DIFF
--- a/src/Suggestion.js
+++ b/src/Suggestion.js
@@ -61,7 +61,7 @@ class Suggestion extends Component {
 
     let { id, display } = suggestion
 
-    if (!id || !display) {
+    if (id === undefined || !display) {
       return id
     }
 


### PR DESCRIPTION
Fixes #277 

Allows ID field in mention data to be 0. Falsy check would previously error out if id field was zero- checks for undefined instead to avoid this behaviour