### PR TITLE
Add failing test for custom regex that contains trigger

### DIFF
--- a/test/MentionsInput.spec.js
+++ b/test/MentionsInput.spec.js
@@ -164,6 +164,27 @@ describe('MentionsInput', () => {
       '@A and @B and :invalidId'
     )
   })
+  
+  it('should handle a custom regex attribute with the trigger', () => {
+    const data = [{ id: 'one', display: '@Brian' }, { id: 'two', display: '@Bryn' }]
+    const wrapper = mount(
+      <MentionsInput
+        value="@Brian and @Bryn"
+        markup="@__id__"
+        regex={/@(\S+)/g}
+        displayTransform={id => `@${id}`}
+      >
+        <Mention trigger="@" data={data} />
+      </MentionsInput>,
+      {
+        attachTo: host,
+      }
+    )
+    wrapper.find('textarea').simulate('focus')
+    expect(wrapper.find('textarea').getDOMNode().value).toEqual(
+      '@one and @two'
+    )
+  })
 
   it('should forward the `inputRef` prop to become the `ref` of the input', () => {
     const inputRef = React.createRef()

--- a/test/MentionsInput.spec.js
+++ b/test/MentionsInput.spec.js
@@ -166,10 +166,10 @@ describe('MentionsInput', () => {
   })
   
   it('should handle a custom regex attribute with the trigger', () => {
-    const data = [{ id: 'one', display: '@Brian' }, { id: 'two', display: '@Bryn' }]
+    const data = [{ id: 'brian', display: 'brian' }, { id: 'bryn', display: 'bryn' }]
     const wrapper = mount(
       <MentionsInput
-        value="@Brian and @Bryn"
+        value="@brian and @bryn"
         markup="@__id__"
         regex={/@(\S+)/g}
         displayTransform={id => `@${id}`}
@@ -182,7 +182,7 @@ describe('MentionsInput', () => {
     )
     wrapper.find('textarea').simulate('focus')
     expect(wrapper.find('textarea').getDOMNode().value).toEqual(
-      '@one and @two'
+      '@brian and @bryn'
     )
   })
 


### PR DESCRIPTION
**What did you change (functionally and technically)?**

I want to add mentions to my input which show `@max` and also send `@max` to the server. I thought the custom regexp feature introduced in #255 would help me achieve that, but it only seems to work if the custom regex does not include the trigger.

I would love for this to work, any ideas what the necessary change would be?
