### PR TITLE
modify japanise copy bug

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -311,16 +311,17 @@ class MentionsInput extends React.Component {
     let newPlainTextValue = ev.target.value
 
     // Derive the new value to set by applying the local change in the textarea's plain text
-    let newValue = applyChangeToValue(
-      value,
-      markup,
-      newPlainTextValue,
-      this.state.selectionStart,
-      this.state.selectionEnd,
-      ev.target.selectionEnd,
-      displayTransform,
-      regex
-    )
+    let newValue = newPlainTextValue === '@' ?
+      applyChangeToValue(
+        value,
+        markup,
+        newPlainTextValue,
+        this.state.selectionStart,
+        this.state.selectionEnd,
+        ev.target.selectionEnd,
+        displayTransform,
+        regex
+      ) : newPlainTextValue
 
     // In case a mention is deleted, also adjust the new plain text value
     newPlainTextValue = getPlainText(newValue, markup, displayTransform, regex)


### PR DESCRIPTION
Fixes #242

What did you change (functionally and technically)?

When input two or more syllable words and then touch space key or select word, to be copied.
So I add code to ignore `applyChangeToValue()`, if there is no @.

I modify this and actually check it, it will work for Japanese.
