### PR TITLE
Prevent crash from recursive calls to setState.

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -566,8 +566,12 @@ class MentionsInput extends React.Component {
     this.updateSuggestionsPosition()
   }
 
-  componentDidUpdate(prevProps) {
-    this.updateSuggestionsPosition()
+  componentDidUpdate(prevProps, prevState) {
+    // Update position of suggestions unless this componentDidUpdate was
+    // triggered by an update to suggestionsPosition.
+    if (prevState.suggestionsPosition === this.state.suggestionsPosition) {
+      this.updateSuggestionsPosition()
+    }
 
     // maintain selection in case a mention is added/removed causing
     // the cursor to jump to the end


### PR DESCRIPTION
Lots of users reported a crash on https://app.amazingmarvin.com after I updated to react 16.8.  It was not very easy to reproduce, but in some cases in MentionsInput.js: setState calls updateSuggestionsPosition which calls setState which calls updateSuggestionsPosition... until it crashes.

This PR prevents such recursive calls to setState.

What did you change (functionally and technically)?

I made it so that only `componentDidUpdate` calls where something other than `suggestionPosition` changes trigger a call to `updateSuggestionsPosition`.

**Checklist**
* Are there tests for the new code? I don't know how to do this.
* Does the code comply to our code conventions? I'm not sure. I don't know where these are.

Feel free to leave this open for a bit since I (and Marvin users) will be testing this further.