### PR TITLE
Add allowSpaceInQuery to propTypes

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -72,6 +72,7 @@ const propTypes = {
    * instead of a textarea
    */
   singleLine: PropTypes.bool,
+  allowSpaceInQuery: PropTypes.bool,
 
   value: PropTypes.string,
   onKeyDown: PropTypes.func,


### PR DESCRIPTION
Fixes #325 

Add `allowSpaceInQuery` to propTypes so it gets stripped out of the props that get passed down to the textarea.