### PR TITLE
Add max suggestions prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | allowSpaceInQuery     | boolean                                                 | false          | Keep suggestions open even if the user separates keywords with spaces.                 |
 | suggestionsPortalHost | DOM Element                                             | undefined      | Render suggestions into the DOM in the supplied host element.                          |
 | inputRef              | React ref                                               | undefined      | Accepts a React ref to forward to the underlying input element                         |
+| maxSuggestions        | number                                                  | undefined      | An upper bound on the number of suggestions rendered                         |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/demo/src/examples/Advanced.js
+++ b/demo/src/examples/Advanced.js
@@ -32,6 +32,7 @@ function Advanced({ value, data, onChange, onBlur, onAdd }) {
         onBlur={onBlur}
         style={style}
         inputRef={inputEl}
+        maxSuggestions={5}
       >
         <Mention
           markup="{{__id__}}"

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -74,7 +74,6 @@ const propTypes = {
   EXPERIMENTAL_cutCopyPaste: PropTypes.bool,
 
   value: PropTypes.string,
-  maxSuggestions: PropTypes.number,
   onKeyDown: PropTypes.func,
   onSelect: PropTypes.func,
   onBlur: PropTypes.func,
@@ -92,7 +91,13 @@ const propTypes = {
           : PropTypes.instanceOf(Element),
     }),
   ]),
-
+  maxSuggestions: (props, propName, componentName) => {
+    if (props[propName] < 1) {
+      return new Error(
+        `Invalid prop ${propName} supplied to ${componentName}. Must be greater than or equal to 1.`
+      )
+    }
+  },
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -531,7 +531,7 @@ class MentionsInput extends React.Component {
 
   handleKeyDown = ev => {
     // do not intercept key events if the suggestions overlay is not shown
-    const suggestionsCount = countSuggestions(this.state.suggestions)
+    const suggestionsCount = countSuggestions(this.state.suggestions, this.props.maxSuggestions)
 
     const suggestionsComp = this.suggestionsRef
     if (suggestionsCount === 0 || !suggestionsComp) {
@@ -572,7 +572,7 @@ class MentionsInput extends React.Component {
   }
 
   shiftFocus = delta => {
-    const suggestionsCount = countSuggestions(this.state.suggestions)
+    const suggestionsCount = countSuggestions(this.state.suggestions, this.props.maxSuggestions)
 
     this.setState({
       focusIndex:
@@ -853,7 +853,7 @@ class MentionsInput extends React.Component {
     }
 
     const { focusIndex } = this.state
-    const suggestionsCount = countSuggestions(this.suggestions)
+    const suggestionsCount = countSuggestions(this.suggestions, this.props.maxSuggestions)
     this.setState({
       suggestions: this.suggestions,
       focusIndex:

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -74,6 +74,7 @@ const propTypes = {
   EXPERIMENTAL_cutCopyPaste: PropTypes.bool,
 
   value: PropTypes.string,
+  maxSuggestions: PropTypes.number,
   onKeyDown: PropTypes.func,
   onSelect: PropTypes.func,
   onBlur: PropTypes.func,
@@ -262,6 +263,7 @@ class MentionsInput extends React.Component {
           })
         }
         isLoading={this.isLoading()}
+        maxSuggestions={this.props.maxSuggestions}
       >
         {this.props.children}
       </SuggestionsOverlay>

--- a/src/MentionsInput.spec.js
+++ b/src/MentionsInput.spec.js
@@ -393,4 +393,25 @@ describe('MentionsInput', () => {
       expect(newPlainTextValue).toMatchSnapshot()
     })
   })
+
+  it('respects the maxSuggestions limit', () => {
+    const maxSuggestions = 1
+
+    const wrapper = mount(
+      <MentionsInput
+        className={'testClass'}
+        value={'@'}
+        maxSuggestions={maxSuggestions}
+      >
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    wrapper.find('textarea').simulate('focus')
+    wrapper.find('textarea').simulate('select', {
+      target: { selectionStart: 1, selectionEnd: 1 },
+    })
+
+    expect(wrapper.find('SuggestionsOverlay').find('Suggestion').length).toEqual(maxSuggestions)
+  })
 })

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -51,10 +51,10 @@ class SuggestionsOverlay extends Component {
   }
 
   render() {
-    const { suggestions, isLoading, style, onMouseDown } = this.props
+    const { suggestions, isLoading, style, onMouseDown, maxSuggestions } = this.props
 
     // do not show suggestions until there is some data
-    if (countSuggestions(suggestions) === 0 && !isLoading) {
+    if (countSuggestions(suggestions, maxSuggestions) === 0 && !isLoading) {
       return null
     }
 

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -9,6 +9,7 @@ import LoadingIndicator from './LoadingIndicator'
 class SuggestionsOverlay extends Component {
   static propTypes = {
     suggestions: PropTypes.object.isRequired,
+    maxSuggestions: PropTypes.number,
     focusIndex: PropTypes.number,
     scrollFocusedIntoView: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -75,12 +76,16 @@ class SuggestionsOverlay extends Component {
 
   renderSuggestions() {
     return Object.values(this.props.suggestions).reduce(
-      (accResults, { results, queryInfo }) => [
+      (accResults, { results, queryInfo }) => {
+        const visibleResults = this.props.maxSuggestions ? results.slice(0, this.props.maxSuggestions) : results
+
+        return [
         ...accResults,
-        ...results.map((result, index) =>
+        ...visibleResults.map((result, index) =>
           this.renderSuggestion(result, queryInfo, accResults.length + index)
         ),
-      ],
+        ]
+      },
       []
     )
   }

--- a/src/utils/countSuggestions.js
+++ b/src/utils/countSuggestions.js
@@ -1,5 +1,5 @@
-const countSuggestions = suggestions =>
-  Object.values(suggestions).reduce(
+const countSuggestions = (suggestions, maxSuggestions) =>
+  maxSuggestions || Object.values(suggestions).reduce(
     (acc, { results }) => acc + results.length,
     0
   )

--- a/src/utils/countSuggestions.js
+++ b/src/utils/countSuggestions.js
@@ -1,7 +1,8 @@
+import { isUndefined } from 'lodash'
+
 const countSuggestions = (suggestions, maxSuggestions) =>
-  maxSuggestions || Object.values(suggestions).reduce(
-    (acc, { results }) => acc + results.length,
-    0
-  )
+  isUndefined(maxSuggestions)
+    ? Object.values(suggestions).reduce((acc, { results }) => acc + results.length, 0)
+    : maxSuggestions
 
 export default countSuggestions


### PR DESCRIPTION
Adds an optional upper bound on the number of suggestions displayed

What did you change (functionally and technically)?

This change provides a prop `maxSuggestions` which enables limiting the number of rendered suggestions to the given maximum.
It also includes an update to the README to document the new prop, as well as a test covering the functionality.

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code? ✅ 
* Does the code comply to our code conventions? ✅ 
* Does the PR resolve the whole issue? ✅ 

**Additional review hints** (remove this list before you submit the PR)
* Besides the code review, what should the reviewer test?
~When I ran the test suite, there were a number of failing tests on master. I removed the Enzyme `attachTo` option which fixed all tests, but I didn't really investigate the relevant comment regarding why this was needed.~ Undid this change post-rebase with origin/master

* Are there any edge cases?
No

* Do you have any test files or test set-up?
Yes, added to an existing file in the suite.

* Could your changes cause side effects elsewhere in the code base?
Not AFAIK
