### PR TITLE
fix: Support experimental copy & paste in IE 11

### DIFF
--- a/demo/src/examples/ExperimentalCutCopyPaste.js
+++ b/demo/src/examples/ExperimentalCutCopyPaste.js
@@ -25,6 +25,7 @@ function ExperimentalCutCopyPaste({ data }) {
         In order to activate this functionality you need to set the
         EXPERIMENTAL__cutCopyPaste flag on a MentionsInput to true .
       </p>
+      <p>This functionality is not supported in Internet Explorer.</p>
 
       <div style={{ display: 'flex' }}>
         <div style={{ flex: 1, paddingRight: 8 }}>

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -324,6 +324,9 @@ class MentionsInput extends React.Component {
     if (event.target !== this.inputRef) {
       return
     }
+    if (!this.supportsClipboardActions(event)) {
+      return
+    }
 
     event.preventDefault()
 
@@ -385,8 +388,15 @@ class MentionsInput extends React.Component {
     )
   }
 
+  supportsClipboardActions(event) {
+    return !!event.clipboardData
+  }
+
   handleCopy(event) {
     if (event.target !== this.inputRef) {
+      return
+    }
+    if (!this.supportsClipboardActions(event)) {
       return
     }
 
@@ -397,6 +407,9 @@ class MentionsInput extends React.Component {
 
   handleCut(event) {
     if (event.target !== this.inputRef) {
+      return
+    }
+    if (!this.supportsClipboardActions(event)) {
       return
     }
 

--- a/src/MentionsInput.spec.js
+++ b/src/MentionsInput.spec.js
@@ -281,6 +281,30 @@ describe('MentionsInput', () => {
       }
     )
 
+    it.each(['cut', 'copy'])(
+      'should fallback to the browsers behaviour if the "%s" event does not support clipboardData',
+      eventType => {
+        // IE 11 has no clipboardData attached to the event and only supports mime type "text"
+        // therefore, the new mechanism should ignore those events and let the browser handle them
+        const textarea = component.find('textarea')
+
+        const selectionStart = plainTextValue.indexOf('First') + 2
+        const selectionEnd = plainTextValue.length
+
+        textarea.simulate('select', {
+          target: { selectionStart, selectionEnd },
+        })
+
+        const preventDefault = jest.fn()
+        const event = new Event(eventType, { bubbles: true })
+        event.preventDefault = preventDefault
+
+        textarea.getDOMNode().dispatchEvent(event)
+
+        expect(preventDefault).not.toHaveBeenCalled()
+      }
+    )
+
     it('should remove a leading mention from the value when the text is cut.', () => {
       const onChange = jest.fn()
 
@@ -391,6 +415,27 @@ describe('MentionsInput', () => {
 
       expect(newValue).toMatchSnapshot()
       expect(newPlainTextValue).toMatchSnapshot()
+    })
+
+    it('should fallback to the browsers behaviour if the "paste" event does not support clipboardData', () => {
+      // IE 11 has no clipboardData attached to the event and only supports mime type "text"
+      // therefore, the new mechanism should ignore those events and let the browser handle them
+      const textarea = component.find('textarea')
+
+      const selectionStart = plainTextValue.indexOf('First') + 2
+      const selectionEnd = plainTextValue.length
+
+      textarea.simulate('select', {
+        target: { selectionStart, selectionEnd },
+      })
+
+      const preventDefault = jest.fn()
+      const event = new Event('paste', { bubbles: true })
+      event.preventDefault = preventDefault
+
+      textarea.getDOMNode().dispatchEvent(event)
+
+      expect(preventDefault).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Fixes #348 

~I added a fallback to use `window.clipboardData` when `event.clipboardData` is not defined, which is the case in IE 11, when the new experimental copy and paste feature is used.~

Following the investigation in this PR, I disabled the new cut, copy, paste mechanism for browsers whose events do not have `clipboardData` attached to the event. This concerns mostly IE. 

In IE 11 the `clipboardData` object is attached to `window` and only supports mime type `text`. Therefore, the new mechanism will not work anyway as it makes use of two different mime types.

How to test?
1. Open IE 11
2. Go to https://react-mentions.wolf-pack.now.sh
3. Scroll to the EXPERIMENTAL section
4. Copy the text with mentions
5. Paste it in the next input