### PR TITLE
Fix CSS Modules example

### DIFF
--- a/demo/src/examples/CssModules.js
+++ b/demo/src/examples/CssModules.js
@@ -11,7 +11,7 @@ function CssModules({ value, data, onChange }) {
     <div className="advanced">
       <h3>Styling with css modules</h3>
 
-      <MentionsInput value={value} onChange={onChange} classNames={classNames}>
+      <MentionsInput value={value} onChange={onChange} className="mentions" classNames={classNames}>
         <Mention data={data} className={classNames.mentions__mention} />
       </MentionsInput>
     </div>


### PR DESCRIPTION
Fixes CSS Modules example

**What did you change (functionally and technically)?**

In the course of implementing react-mentions with (S)CSS modules, I found that we also need to provide a base class name for the substyled-component to generate its expected class names from.

This fixes that in the example.