### PR TITLE
Workaround of browsers not firing compositionEnd event

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -454,6 +454,7 @@ class MentionsInput extends React.Component {
 
   // Handle input element's change event
   handleChange = ev => {
+    isComposing = false
     // if we are inside iframe, we need to find activeElement within its contentDocument
     const currentDocument =
       (document.activeElement && document.activeElement.contentDocument) ||


### PR DESCRIPTION
It is discovered that compositionEnd event will not fire if all of the following conditions are matched

1. Use Chrome / Firefox
2. Use Sucheng input method
3. select suggestion by 'enter' which the display item ends with a character that only requires one char to input for the method, for example, '手'，'田'，'水'，'口'，'人'

This issue leads to suggestion item like '所有人' ends up to become '@[所有人](all)人', which expected result should be '@[所有人](all)'
