### PR TITLE
fix(pattern): remove required blank character before trigger

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -33,7 +33,7 @@ export const makeTriggerRegex = function(trigger, options = {}) {
     // first capture group is the part to be replaced on completion
     // second capture group is for extracting the search query
     return new RegExp(
-      `(?:^|\\s)(${escapedTriggerChar}([^${
+      `(${escapedTriggerChar}([^${
         allowSpaceInQuery ? '' : '\\s'
       }${escapedTriggerChar}]*))$`
     )


### PR DESCRIPTION
Fixes #remove required blank character before trigger

I think the required blank character before trigger is unnecessary, so I removed it.