### PR TITLE
Apply "right" positioning for SuggestionsOverlay

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -244,13 +244,14 @@ class MentionsInput extends React.Component {
       return null
     }
 
-    const { position, left, top } = this.state.suggestionsPosition
+    const { position, left, right, top } = this.state.suggestionsPosition
 
     const suggestionsNode = (
       <SuggestionsOverlay
         style={this.props.style('suggestions')}
         position={position}
         left={left}
+        right={right}
         top={top}
         focusIndex={this.state.focusIndex}
         scrollFocusedIntoView={this.state.scrollFocusedIntoView}
@@ -732,6 +733,7 @@ class MentionsInput extends React.Component {
 
     if (
       position.left === this.state.suggestionsPosition.left &&
+      position.right === this.state.suggestionsPosition.right &&
       position.top === this.state.suggestionsPosition.top &&
       position.position === this.state.suggestionsPosition.position
     ) {

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -13,6 +13,7 @@ class SuggestionsOverlay extends Component {
     focusIndex: PropTypes.number,
     position: PropTypes.string,
     left: PropTypes.number,
+    right: PropTypes.number,
     top: PropTypes.number,
     scrollFocusedIntoView: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -72,6 +73,7 @@ class SuggestionsOverlay extends Component {
       containerRef,
       position,
       left,
+      right,
       top,
     } = this.props
 
@@ -82,7 +84,7 @@ class SuggestionsOverlay extends Component {
 
     return (
       <div
-        {...inline({ position: position || 'absolute', left, top }, style)}
+        {...inline({ position: position || 'absolute', left, right, top }, style)}
         onMouseDown={onMouseDown}
         ref={containerRef}
       >


### PR DESCRIPTION
Fixes #425 by correctly positioning the suggestions overlay at the right side of the input when appropriate.

* Adds `right` as a property for `SuggestionsOverlay`.
* Includes `right` when destructuring and checking for changes in `suggestionsPosition` in the `MentionsInput` component. Passes this value into `SuggestionsOverlay`.