### PR TITLE
Fix positioning suggestions list in React portals

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -91,7 +91,6 @@ const propTypes = {
           : PropTypes.instanceOf(Element),
     }),
   ]),
-
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
@@ -657,7 +656,7 @@ class MentionsInput extends React.Component {
     const caretHeight = getComputedStyleLengthProp(highlighter, 'font-size')
     const viewportRelative = {
       left: caretOffsetParentRect.left + caretPosition.left,
-      top: caretOffsetParentRect.top + caretPosition.top + caretHeight,
+      top: caretOffsetParentRect.top + caretPosition.top + caretHeight + window.scrollHeight,
     }
     const viewportHeight = Math.max(
       document.documentElement.clientHeight,


### PR DESCRIPTION
I tried the provided examples for positioning the suggestions list within a React portal but was unsuccessful by mimicking the examples. The opening suggestions list would bounce if up and down and it's position would change as I scrolled the page (the css top value would change for some reason).

Looking at the source code I noticed that the suggestion list is positioned next to the highlighter/input 

```
const caretOffsetParentRect = highlighter.getBoundingClientRect()
    const caretHeight = getComputedStyleLengthProp(highlighter, 'font-size')
    const viewportRelative = {
      left: caretOffsetParentRect.left + caretPosition.left,
      top: caretOffsetParentRect.top + caretPosition.top + caretHeight,
    }
```

However, this code doesn't take into account the scroll position of the window, so that the position of the suggestions list would open up in a correct position if the user first scrolls down. Right now, the suggestions list is rendered a certain px amount from the top, which is will display wrongly, if the user scrolls down a bit, and then types something to open the suggestion list.
