### PR TITLE
Wrong conversion of markup to regex

### DIFF
--- a/src/utils/markupToRegex.js
+++ b/src/utils/markupToRegex.js
@@ -6,7 +6,7 @@ const markupToRegex = markup => {
   const charAfterDisplay =
     markup[markup.indexOf(PLACEHOLDERS.display) + PLACEHOLDERS.display.length]
   const charAfterId =
-    markup[markup.indexOf(PLACEHOLDERS.display) + PLACEHOLDERS.display.length]
+    markup[markup.indexOf(PLACEHOLDERS.id) + PLACEHOLDERS.id.length]
   return new RegExp(
     escapedMarkup
       .replace(

--- a/src/utils/markupToRegex.spec.js
+++ b/src/utils/markupToRegex.spec.js
@@ -27,4 +27,9 @@ describe('#markupToRegex', () => {
     const regex = markupToRegex('@[__display__](foo:__id__)')
     expect(regex.exec('Hi @[Foo], how are you ](foo:1)')).toEqual(null)
   })
+  
+  it('should parse regex that doesn\'t use "display"', () => {
+    const regex = markupToRegex('[tag id=__id__ /]')
+    expect(regex.exec('[tag id=italy /]')[1]).toEqual('italy')
+  })
 })


### PR DESCRIPTION
Fixes #429 

The function "markupToRegex" at line 9 https://github.com/signavio/react-mentions/blob/master/src/utils/markupToRegex.js#L9
Refer to display, not to id

the result of 
markupToRegex("[tag id=id /]") 
was returning 
/[tag\ id=([^i]+?)\ /]/

escaping all "i" from the id
