### PR TITLE
Adding all properties of target object in onChange event

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -512,7 +512,7 @@ class MentionsInput extends React.Component {
 
     // Propagate change
     // let handleChange = this.getOnChange(this.props) || emptyFunction;
-    let eventMock = { target: { value: newValue } }
+    let eventMock = { target: { ...ev.target, value: newValue } }
     // this.props.onChange.call(this, eventMock, newValue, newPlainTextValue, mentions);
     this.executeOnChange(eventMock, newValue, newPlainTextValue, mentions)
   }


### PR DESCRIPTION
I need all the properties from the `event.target` object, but only the `value` property is received in the `onChange` callback. So, just made a small addition to including all the properties.