### PR TITLE
Added support to disable suggestion selection

### DIFF
--- a/demo/src/examples/Examples.js
+++ b/demo/src/examples/Examples.js
@@ -21,6 +21,7 @@ const users = [
   {
     id: 'jesse',
     display: 'Jesse Pinkman',
+    disabled: true,
   },
   {
     id: 'gus',

--- a/demo/src/examples/defaultStyle.js
+++ b/demo/src/examples/defaultStyle.js
@@ -46,6 +46,10 @@ export default {
       '&focused': {
         backgroundColor: '#cee4e5',
       },
+      '&disabled': {
+        opacity: '0.3',
+        cursor: 'default',
+      },
     },
   },
 }

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -921,10 +921,11 @@ class MentionsInput extends React.Component {
   }
 
   addMention = (
-    { id, display },
+    { id, display, disabled },
     { childIndex, querySequenceStart, querySequenceEnd, plainTextValue }
   ) => {
     // Insert mention in the marked up value at the correct position
+    if(disabled) return;
     const value = this.props.value || ''
     const config = readConfigFromChildren(this.props.children)
     const mentionsChild = Children.toArray(this.props.children)[childIndex]

--- a/src/Suggestion.js
+++ b/src/Suggestion.js
@@ -17,6 +17,7 @@ class Suggestion extends Component {
         id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
           .isRequired,
         display: PropTypes.string,
+        disabled: PropTypes.string
       }),
     ]).isRequired,
     renderSuggestion: PropTypes.func,
@@ -96,7 +97,7 @@ const styled = defaultStyle(
   {
     cursor: 'pointer',
   },
-  props => ({ '&focused': props.focused })
+  props => ({ '&focused': props.focused, '&disabled': props.disabled })
 )
 
 export default styled(Suggestion)

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -127,6 +127,7 @@ class SuggestionsOverlay extends Component {
         renderSuggestion={renderSuggestion}
         suggestion={result}
         focused={isFocused}
+        disabled={result.disabled}
         onClick={() => this.select(result, queryInfo)}
         onMouseEnter={() => this.handleMouseEnter(index)}
       />
@@ -148,7 +149,9 @@ class SuggestionsOverlay extends Component {
   }
 
   select = (suggestion, queryInfo) => {
-    this.props.onSelect(suggestion, queryInfo)
+    if(!suggestion.disabled) {
+      this.props.onSelect(suggestion, queryInfo)
+    }
   }
 
   setUlElement = (el) => {


### PR DESCRIPTION
Fixes #ABC

Added support to disable mention suggestion, it's useful when you need to display the whole list but disable the ability to select smbdy.

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code? -

**Additional review hints** (remove this list before you submit the PR)
It shouldn't break any functionality as it's just preventing events. 
