### PR TITLE
add the ability to force mentions to be rendered on top of the input

### DIFF
--- a/demo/src/examples/BottomGuard.js
+++ b/demo/src/examples/BottomGuard.js
@@ -20,7 +20,9 @@ function BottomGuard({ value, data, onChange, onAdd }) {
       <h3>Bottom guard example</h3>
       <p>
         Note that the bottom input will open the suggestions list above the
-        cursor
+        cursor.
+        Also, the middle one will render its suggestions always on top,
+        even if it has enough space below.
       </p>
       <div
         style={{
@@ -47,6 +49,16 @@ function BottomGuard({ value, data, onChange, onAdd }) {
         <br />
         <br />
         <br />
+        <MentionsInput
+          value={value}
+          onChange={onChange}
+          style={defaultStyle}
+          placeholder={"Mention people using '@'"}
+          suggestionsPortalHost={container}
+          forceSuggestionsAboveCursor={true}
+        >
+          <Mention data={data} onAdd={onAdd} style={defaultMentionStyle} />
+        </MentionsInput>
         <br />
         <br />
         <br />

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -71,6 +71,7 @@ const propTypes = {
   singleLine: PropTypes.bool,
   allowSpaceInQuery: PropTypes.bool,
   allowSuggestionsAboveCursor: PropTypes.bool,
+  forceSuggestionsAboveCursor: PropTypes.bool,
   ignoreAccents: PropTypes.bool,
 
   value: PropTypes.string,
@@ -644,7 +645,7 @@ class MentionsInput extends React.Component {
 
   updateSuggestionsPosition = () => {
     let { caretPosition } = this.state
-    const { suggestionsPortalHost, allowSuggestionsAboveCursor } = this.props
+    const { suggestionsPortalHost, allowSuggestionsAboveCursor, forceSuggestionsAboveCursor } = this.props
 
     if (!caretPosition || !this.suggestionsElement) {
       return
@@ -695,9 +696,10 @@ class MentionsInput extends React.Component {
       // Move the list up above the caret if it's getting cut off by the bottom of the window, provided that the list height
       // is small enough to NOT cover up the caret
       if (
-        allowSuggestionsAboveCursor &&
+        (allowSuggestionsAboveCursor &&
         top + suggestions.offsetHeight > viewportHeight &&
-        suggestions.offsetHeight < top - caretHeight
+          suggestions.offsetHeight < top - caretHeight) ||
+          forceSuggestionsAboveCursor
       ) {
         position.top = Math.max(0, top - suggestions.offsetHeight - caretHeight)
       } else {


### PR DESCRIPTION
Currently, mentions can be rendered on top of the input/textarea only if the space below is not enough.
For my usecase, I wanted the mentions to be rendered on top of it always. So I added a boolean to do this.

