### PR TITLE
Support of assistive technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | suggestionsPortalHost       | DOM Element                                             | undefined      | Render suggestions into the DOM in the supplied host element.                          |
 | inputRef                    | React ref                                               | undefined      | Accepts a React ref to forward to the underlying input element                         |
 | allowSuggestionsAboveCursor | boolean                                                 | false          | Renders the SuggestionList above the cursor if there is not enough space below         |
+| a11ySuggestionsListLabel    | string                                                  | `''`           | This label would be exposed to screen readers when suggestion popup appears            |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/demo/src/examples/Advanced.js
+++ b/demo/src/examples/Advanced.js
@@ -33,6 +33,7 @@ function Advanced({ value, data, onChange, onBlur, onAdd }) {
         onBlur={onBlur}
         style={style}
         inputRef={inputEl}
+        a11ySuggestionsListLabel={"Suggested mentions"}
       >
         <Mention
           markup="{{__id__}}"

--- a/demo/src/examples/AsyncGithubUserMentions.js
+++ b/demo/src/examples/AsyncGithubUserMentions.js
@@ -29,6 +29,7 @@ function AsyncGithubUserMentions({ value, data, onChange }) {
         onChange={onChange}
         style={defaultStyle}
         placeholder="Mention any Github user by typing `@` followed by at least one char"
+        a11ySuggestionsListLabel={"Suggested Github users for mention"}
       >
         <Mention
           displayTransform={login => `@${login}`}

--- a/demo/src/examples/BottomGuard.js
+++ b/demo/src/examples/BottomGuard.js
@@ -37,6 +37,7 @@ function BottomGuard({ value, data, onChange, onAdd }) {
           onChange={onChange}
           style={defaultStyle}
           placeholder={"Mention people using '@'"}
+          a11ySuggestionsListLabel={"Suggested mentions"}
           suggestionsPortalHost={container}
           allowSuggestionsAboveCursor={true}
         >
@@ -56,6 +57,7 @@ function BottomGuard({ value, data, onChange, onAdd }) {
           onChange={onChange}
           style={defaultStyle}
           placeholder={"Mention people using '@'"}
+          a11ySuggestionsListLabel={"Suggested mentions"}
           suggestionsPortalHost={container}
           allowSuggestionsAboveCursor={true}
         >

--- a/demo/src/examples/CssModules.js
+++ b/demo/src/examples/CssModules.js
@@ -16,6 +16,7 @@ function CssModules({ value, data, onChange }) {
         onChange={onChange}
         className="mentions"
         classNames={classNames}
+        a11ySuggestionsListLabel={"Suggested mentions"}
       >
         <Mention data={data} className={classNames.mentions__mention} />
       </MentionsInput>

--- a/demo/src/examples/CutCopyPaste.js
+++ b/demo/src/examples/CutCopyPaste.js
@@ -65,6 +65,7 @@ const MultiMention = ({ value, data, onChange, onAdd }) => (
     onChange={onChange}
     style={defaultStyle}
     placeholder={"Mention people using '@'"}
+    a11ySuggestionsListLabel={"Suggested mentions"}
   >
     <Mention
       markup="@[__display__](user:__id__)"

--- a/demo/src/examples/MultipleTrigger.js
+++ b/demo/src/examples/MultipleTrigger.js
@@ -22,6 +22,7 @@ function MultipleTriggers({ value, data, onChange, onAdd }) {
         onChange={onChange}
         style={defaultStyle}
         placeholder={"Mention people using '@'"}
+        a11ySuggestionsListLabel={"Suggested mentions"}
       >
         <Mention
           markup="@[__display__](user:__id__)"
@@ -45,7 +46,7 @@ function MultipleTriggers({ value, data, onChange, onAdd }) {
         <Mention
           markup="@[__display__](email:__id__)"
           trigger={emailRegex}
-          data={search => [{ id: search, display: search }]}
+          data={(search) => [{ id: search, display: search }]}
           onAdd={onAdd}
           style={{ backgroundColor: '#d1c4e9' }}
         />

--- a/demo/src/examples/Scrollable.js
+++ b/demo/src/examples/Scrollable.js
@@ -33,6 +33,7 @@ function Scrollable({ value, data, onChange, onAdd }) {
         onChange={onChange}
         style={style}
         placeholder={"Mention people using '@'"}
+        a11ySuggestionsListLabel={"Suggested mentions"}
       >
         <Mention
           markup="@[__display__](user:__id__)"

--- a/demo/src/examples/SingleLine.js
+++ b/demo/src/examples/SingleLine.js
@@ -17,6 +17,7 @@ function SingleLine({ value, data, onChange, onAdd }) {
         onChange={onChange}
         style={defaultStyle}
         placeholder={"Mention people using '@'"}
+        a11ySuggestionsListLabel={"Suggested mentions"}
       >
         <Mention data={data} onAdd={onAdd} style={defaultMentionStyle} />
       </MentionsInput>

--- a/demo/src/examples/SingleLineIgnoringAccents.js
+++ b/demo/src/examples/SingleLineIgnoringAccents.js
@@ -18,6 +18,7 @@ function SingleLineIgnoringAccents({ value, data, onChange, onAdd }) {
         style={defaultStyle}
         placeholder={"Mention people using '@'"}
         ignoreAccents
+        a11ySuggestionsListLabel={"Suggested mentions"}
       >
         <Mention data={data} onAdd={onAdd} style={defaultMentionStyle} />
       </MentionsInput>

--- a/demo/src/examples/SuggestionPortal.js
+++ b/demo/src/examples/SuggestionPortal.js
@@ -44,6 +44,7 @@ function SuggestionPortal({ value, data, onChange, onAdd }) {
           onChange={onChange}
           style={defaultStyle}
           placeholder={"Mention people using '@'"}
+          a11ySuggestionsListLabel={"Suggested mentions"}
           suggestionsPortalHost={container}
         >
           <Mention data={data} onAdd={onAdd} style={defaultMentionStyle} />
@@ -55,6 +56,7 @@ function SuggestionPortal({ value, data, onChange, onAdd }) {
           onChange={onChange}
           style={scrollableStyle}
           placeholder={"Mention people using '@'"}
+          a11ySuggestionsListLabel={"Suggested mentions"}
           suggestionsPortalHost={container}
         >
           <Mention data={data} onAdd={onAdd} style={defaultMentionStyle} />

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -15,6 +15,7 @@ import {
   isNumber,
   keys,
   omit,
+  getSuggestionHtmlId,
 } from './utils'
 
 import Highlighter from './Highlighter'
@@ -72,6 +73,7 @@ const propTypes = {
   allowSpaceInQuery: PropTypes.bool,
   allowSuggestionsAboveCursor: PropTypes.bool,
   ignoreAccents: PropTypes.bool,
+  a11ySuggestionsListLabel: PropTypes.string,
 
   value: PropTypes.string,
   onKeyDown: PropTypes.func,
@@ -113,6 +115,9 @@ class MentionsInput extends React.Component {
   constructor(props) {
     super(props)
     this.suggestions = {}
+    this.uuidSuggestionsOverlay = Math.random()
+      .toString(16)
+      .substring(2)
 
     this.handleCopy = this.handleCopy.bind(this)
     this.handleCut = this.handleCut.bind(this)
@@ -199,6 +204,18 @@ class MentionsInput extends React.Component {
           onCompositionEnd: this.handleCompositionEnd,
           onScroll: this.updateHighlighterScroll,
         }),
+
+      ...(this.isOpened() && {
+        role: 'combobox',
+        'aria-controls': this.uuidSuggestionsOverlay,
+        'aria-expanded': true,
+        'aria-autocomplete': 'list',
+        'aria-haspopup': 'listbox',
+        'aria-activedescendant': getSuggestionHtmlId(
+          this.uuidSuggestionsOverlay,
+          this.state.focusIndex
+        ),
+      }),
     }
   }
 
@@ -248,6 +265,7 @@ class MentionsInput extends React.Component {
 
     const suggestionsNode = (
       <SuggestionsOverlay
+        id={this.uuidSuggestionsOverlay}
         style={this.props.style('suggestions')}
         position={position}
         left={left}
@@ -260,7 +278,9 @@ class MentionsInput extends React.Component {
         onMouseDown={this.handleSuggestionsMouseDown}
         onMouseEnter={this.handleSuggestionsMouseEnter}
         isLoading={this.isLoading()}
+        isOpened={this.isOpened()}
         ignoreAccents={this.props.ignoreAccents}
+        a11ySuggestionsListLabel={this.props.a11ySuggestionsListLabel}
       >
         {this.props.children}
       </SuggestionsOverlay>
@@ -984,6 +1004,10 @@ class MentionsInput extends React.Component {
     })
     return isLoading
   }
+
+  isOpened = () =>
+    isNumber(this.state.selectionStart) &&
+    (countSuggestions(this.state.suggestions) !== 0 || this.isLoading())
 
   _queryId = 0
 }

--- a/src/Suggestion.js
+++ b/src/Suggestion.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { defaultStyle } from './utils'
 
-import { getSubstringIndex, keys, omit } from './utils'
+import { getSubstringIndex, keys, omit, getSuggestionHtmlId } from './utils'
 
 class Suggestion extends Component {
   static propTypes = {
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    id: PropTypes.string.isRequired,
     query: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
     ignoreAccents: PropTypes.bool,
@@ -25,14 +25,20 @@ class Suggestion extends Component {
   }
 
   render() {
-    let rest = omit(
+    const rest = omit(
       this.props,
       ['style', 'classNames', 'className'], // substyle props
       keys(Suggestion.propTypes)
     )
 
     return (
-      <li {...rest} {...this.props.style}>
+      <li
+        id={this.props.id}
+        role="option"
+        aria-selected={this.props.focused}
+        {...rest}
+        {...this.props.style}
+      >
         {this.renderContent()}
       </li>
     )
@@ -60,7 +66,7 @@ class Suggestion extends Component {
   getDisplay() {
     let { suggestion } = this.props
 
-    if (suggestion instanceof String) {
+    if (typeof suggestion === 'string') {
       return suggestion
     }
 
@@ -96,7 +102,7 @@ const styled = defaultStyle(
   {
     cursor: 'pointer',
   },
-  props => ({ '&focused': props.focused })
+  (props) => ({ '&focused': props.focused })
 )
 
 export default styled(Suggestion)

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -3,19 +3,22 @@ import PropTypes from 'prop-types'
 import { inline } from 'substyle'
 import { defaultStyle } from './utils'
 
-import { countSuggestions } from './utils'
+import { countSuggestions, getSuggestionHtmlId } from './utils'
 import Suggestion from './Suggestion'
 import LoadingIndicator from './LoadingIndicator'
 
 class SuggestionsOverlay extends Component {
   static propTypes = {
+    id: PropTypes.string.isRequired,
     suggestions: PropTypes.object.isRequired,
+    a11ySuggestionsListLabel: PropTypes.string,
     focusIndex: PropTypes.number,
     position: PropTypes.string,
     left: PropTypes.number,
     top: PropTypes.number,
     scrollFocusedIntoView: PropTypes.bool,
     isLoading: PropTypes.bool,
+    isOpened: PropTypes.bool.isRequired,
     onSelect: PropTypes.func,
     ignoreAccents: PropTypes.bool,
     containerRef: PropTypes.oneOfType([
@@ -65,8 +68,10 @@ class SuggestionsOverlay extends Component {
 
   render() {
     const {
+      id,
       suggestions,
-      isLoading,
+      a11ySuggestionsListLabel,
+      isOpened,
       style,
       onMouseDown,
       containerRef,
@@ -76,7 +81,7 @@ class SuggestionsOverlay extends Component {
     } = this.props
 
     // do not show suggestions until there is some data
-    if (countSuggestions(suggestions) === 0 && !isLoading) {
+    if (!isOpened) {
       return null
     }
 
@@ -86,7 +91,13 @@ class SuggestionsOverlay extends Component {
         onMouseDown={onMouseDown}
         ref={containerRef}
       >
-        <ul ref={this.setUlElement} {...style('list')}>
+        <ul
+          ref={this.setUlElement}
+          id={id}
+          role="listbox"
+          aria-label={a11ySuggestionsListLabel}
+          {...style('list')}
+        >
           {this.renderSuggestions()}
         </ul>
 
@@ -108,7 +119,6 @@ class SuggestionsOverlay extends Component {
   }
 
   renderSuggestion(result, queryInfo, index) {
-    const id = getID(result)
     const isFocused = index === this.props.focusIndex
     const { childIndex, query } = queryInfo
     const { renderSuggestion } = Children.toArray(this.props.children)[
@@ -119,8 +129,8 @@ class SuggestionsOverlay extends Component {
     return (
       <Suggestion
         style={this.props.style('item')}
-        key={`${childIndex}-${id}`}
-        id={id}
+        key={`${childIndex}-${getID(result)}`}
+        id={getSuggestionHtmlId(this.props.id, index)}
         query={query}
         index={index}
         ignoreAccents={ignoreAccents}
@@ -157,7 +167,7 @@ class SuggestionsOverlay extends Component {
 }
 
 const getID = (suggestion) => {
-  if (suggestion instanceof String) {
+  if (typeof suggestion === 'string') {
     return suggestion
   }
 

--- a/src/utils/getSuggestionHtmlId.js
+++ b/src/utils/getSuggestionHtmlId.js
@@ -1,0 +1,3 @@
+const getSuggestionHtmlId = (prefix, id) => `${prefix}-${id}`
+
+export default getSuggestionHtmlId

--- a/src/utils/getSuggestionHtmlId.spec.js
+++ b/src/utils/getSuggestionHtmlId.spec.js
@@ -1,0 +1,10 @@
+import getSuggestionHtmlId from './getSuggestionHtmlId'
+
+describe('#getSuggestionHtmlId', () => {
+  it('Should build a string from provided prefix and id', () => {
+    expect(
+      getSuggestionHtmlId('listid1', 'itemid1')
+    ).toEqual('listid1-itemid1')
+    expect(getSuggestionHtmlId('listid2', 'itemid2')).toEqual('listid2-itemid2')
+  })
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ export {
   default as findStartOfMentionInPlainText,
 } from './findStartOfMentionInPlainText'
 export { default as getMentions } from './getMentions'
+export { default as getSuggestionHtmlId } from './getSuggestionHtmlId'
 export { default as countSuggestions } from './countSuggestions'
 export { default as getEndOfLastMention } from './getEndOfLastMention'
 export { default as mapPlainTextIndex } from './mapPlainTextIndex'


### PR DESCRIPTION
Fixes #451

This PR contains mainly minor changes: required markup for assistive technologies, but some important logical changes were also required.

## Notes:
* Added new property `a11ySuggestionsListLabel ` of `MentionsInput`. This string will be exposed to screen readers when suggestions popup will appear. Demos also were updated to demonstrate it's usage.
* Text input should have specific markup to expose its association with suggestions list. This markup should appear only when the suggestions list is visible. Because of that `isOpen` prop of `SuggestionsOverlay` was created. Suggestions list will appear only when isOpen set to `true`. The value for this property is now calculated in `MentionsInput` with a new method `isOpen()`. In this way, we can strictly link text input properties with the actual appearance of the suggestions list.
* For `SuggestionsOverlay` we create a unique identifier in `MentionsInput`. It is used as HTML ID for the suggestions list and to generate HTML IDs for items list. These IDs linking text input with suggestions Listbox, so that assistive technologies can understand it's existence and active element.
* The `id` property of `Suggestion` component was unused for a long time. Now, it was reused to pass the HTML ID of the suggestion list item. The ID is generated from a unique identifier of the listbox and index of the suggestion. It's generated via `getSuggestionHtmlId` utility function so that we can expose selected item ID in text input markup.

