### PR TITLE
Stopping propagation of handleKeyDown event

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -554,6 +554,7 @@ class MentionsInput extends React.Component {
 
     if (Object.values(KEY).indexOf(ev.keyCode) >= 0) {
       ev.preventDefault()
+      ev.stopPropagation()
     }
 
     switch (ev.keyCode) {


### PR DESCRIPTION
Fixes #444 

Added `ev.stopPropagation()` in handleKeyDown method of `MentionsInput.js` when the keyDown event is handled by react-mentions (e.g. for `RETURN` key the stopPropagation will be called as this event is handled by react-mentions to select the focused suggestion) 
