### PR TITLE
Fix a problem with `emoji support` not working on the example page

### DIFF
--- a/demo/src/examples/Emojis.js
+++ b/demo/src/examples/Emojis.js
@@ -24,12 +24,14 @@ function Emojis({ value, data, onChange, onAdd }) {
   }, [])
 
   const queryEmojis = (query, callback) => {
-    if (query.length < 2) return null
+    if (query.length === 0) return
 
-    const matches = emojis.filter((emoji) => {
-      return emoji.shortname.indexOf(query) > -1
-    })
-    callback(matches.map(({ emoji }) => ({ id: emoji })))
+    const matches = emojis
+      .filter((emoji) => {
+        return emoji.name.indexOf(query.toLowerCase()) > -1
+      })
+      .slice(0, 10)
+    return matches.map(({ emoji }) => ({ id: emoji }))
   }
 
   return (

--- a/demo/src/examples/Emojis.js
+++ b/demo/src/examples/Emojis.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { Mention, MentionsInput } from '../../../src'
 
@@ -6,15 +6,32 @@ import { provideExampleValue } from './higher-order'
 import emojiExampleStyle from './emojiExampleStyle'
 import defaultMentionStyle from './defaultMentionStyle'
 
-const queryEmojis = async (query, callback) => {
-  const url = new URL('https://emoji.getdango.com/api/emoji')
-  url.searchParams.append('q', query)
-  const { results } = await fetch(url).then(res => res.json())
-  callback(results.map(({ text }) => ({ id: text })))
-}
 const neverMatchingRegex = /($a)/
 
 function Emojis({ value, data, onChange, onAdd }) {
+  const [emojis, setEmojis] = useState([])
+
+  useEffect(() => {
+    fetch(
+      'https://gist.githubusercontent.com/oliveratgithub/0bf11a9aff0d6da7b46f1490f86a71eb/raw/d8e4b78cfe66862cf3809443c1dba017f37b61db/emojis.json'
+    )
+      .then((response) => {
+        return response.json()
+      })
+      .then((jsonData) => {
+        setEmojis(jsonData.emojis)
+      })
+  }, [])
+
+  const queryEmojis = (query, callback) => {
+    if (query.length < 2) return null
+
+    const matches = emojis.filter((emoji) => {
+      return emoji.shortname.indexOf(query) > -1
+    })
+    callback(matches.map(({ emoji }) => ({ id: emoji })))
+  }
+
   return (
     <div>
       <h3>Emoji support</h3>
@@ -27,7 +44,7 @@ function Emojis({ value, data, onChange, onAdd }) {
       >
         <Mention
           trigger="@"
-          displayTransform={username => `@${username}`}
+          displayTransform={(username) => `@${username}`}
           markup="@__id__"
           data={data}
           regex={/@(\S+)/}


### PR DESCRIPTION
I submit a simple modification of the example page.

The API for getting the list of emoji returns `ERR_NAME_NOT_RESOLVED`. (The API may be outdated.)
As a result, `Emoji support` cannot be used properly.

Since I couldn't find any other APIs that can be used without a secret key, I modified it so that the `Emoji support` can be used correctly by retrieving it from the JSON of the published emoji list.
You'll see that when you type two or more characters following `:`, a list of Emoji selections will appear.

Since this is just the example page modification, no test code has been added.
