### PR TITLE
feat: implement text direction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | inputRef                    | React ref                                               | undefined      | Accepts a React ref to forward to the underlying input element                         |
 | allowSuggestionsAboveCursor | boolean                                                 | false          | Renders the SuggestionList above the cursor if there is not enough space below         |
 | a11ySuggestionsListLabel    | string                                                  | `''`           | This label would be exposed to screen readers when suggestion popup appears            |
+| _unstableAutoDirection      | boolean                                                 | false          | Enables automatic text direction for both RTL and LTR text per paragraph, experimental |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/demo/src/examples/AutoDirection.js
+++ b/demo/src/examples/AutoDirection.js
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import { Mention, MentionsInput } from '../../../src'
+
+import { provideExampleValue } from './higher-order'
+
+import defaultStyle from './defaultStyle'
+import defaultMentionStyle from './defaultMentionStyle'
+
+function AutoDirection({ value, data, onChange, onAdd }) {
+  return (
+    <div className="multiple-triggers">
+      <h3>Auto direction</h3>
+
+      <MentionsInput
+        value={value}
+        onChange={onChange}
+        style={defaultStyle}
+        placeholder={"Mention people using '@'"}
+        dir="auto"
+        a11ySuggestionsListLabel={"Suggested mentions"}
+        _unstableAutoDirection
+      >
+        <Mention
+          markup="@[__display__](__id__)"
+          displayTransform={(username, displayname) => `@${displayname || username}`}
+          trigger="@"
+          data={data}
+          onAdd={onAdd}
+          style={defaultMentionStyle}
+        />
+      </MentionsInput>
+    </div>
+  )
+}
+
+const asExample = provideExampleValue(
+  "Hi @[John Doe](johndoe), \nסעיף א. כל בני אדם נולדו בני חורין ושווים בערכם ובזכויותיהם. כולם חוננו בתבונה ובמצפון, לפיכך @[John Doe](johndoe) חובה עליהם לנהוג איש ברעהו ברוח של אחוה."
+)
+
+export default asExample(AutoDirection)

--- a/demo/src/examples/Examples.js
+++ b/demo/src/examples/Examples.js
@@ -12,6 +12,7 @@ import SingleLine from './SingleLine'
 import SingleLineIgnoringAccents from './SingleLineIgnoringAccents'
 import SuggestionPortal from './SuggestionPortal'
 import BottomGuard from './BottomGuard'
+import AutoDirection from './AutoDirection'
 
 const users = [
   {
@@ -63,6 +64,7 @@ export default function Examples() {
         <Emojis data={users} />
         <SuggestionPortal data={users} />
         <BottomGuard data={users} />
+        <AutoDirection data={users} />
       </div>
     </StylesViaJss>
   )

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -77,17 +77,12 @@ class Highlighter extends Component {
     this.props.onCaretPositionChange(newPosition)
   }
 
-  render() {
-    const {
-      selectionStart,
-      selectionEnd,
-      value,
-      style,
-      children,
-      containerRef,
-    } = this.props
-    const config = readConfigFromChildren(children)
-
+  renderLine({
+    value,
+    selectionStart,
+    selectionEnd,
+    config
+  }) {
     // If there's a caret (i.e. no range selection), map the caret position into the marked up value
     let caretPositionInMarkup
     if (selectionStart === selectionEnd) {
@@ -161,6 +156,41 @@ class Highlighter extends Component {
     if (components !== resultComponents) {
       // if a caret component is to be rendered, add all components that followed as its children
       resultComponents.push(this.renderHighlighterCaret(components))
+    }
+    return resultComponents
+  }
+
+  render() {
+    const {
+      selectionStart,
+      selectionEnd,
+      value,
+      style,
+      children,
+      containerRef,
+      _unstableAutoDirection,
+    } = this.props
+    const config = readConfigFromChildren(children)
+
+    let resultComponents
+    // If auto direction is used and the value contains newlines, split be \n and iterate over each line separately
+    if (_unstableAutoDirection && value.indexOf('\n') !== -1) {
+      const lines = value.split('\n')
+      resultComponents = lines.map((value, index) => (
+        <div key={index} dir="auto">{this.renderLine({
+          value,
+          selectionStart,
+          selectionEnd,
+          config
+        })}</div>
+      ))
+    } else {
+      resultComponents =this.renderLine({
+        value,
+        selectionStart,
+        selectionEnd,
+        config
+      })
     }
 
     return (

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -297,7 +297,7 @@ class MentionsInput extends React.Component {
 
   renderHighlighter = () => {
     const { selectionStart, selectionEnd } = this.state
-    const { singleLine, children, value, style } = this.props
+    const { singleLine, children, value, style, _unstableAutoDirection } = this.props
 
     return (
       <Highlighter
@@ -308,6 +308,7 @@ class MentionsInput extends React.Component {
         selectionStart={selectionStart}
         selectionEnd={selectionEnd}
         onCaretPositionChange={this.handleCaretPositionChange}
+        _unstableAutoDirection={_unstableAutoDirection}
       >
         {children}
       </Highlighter>


### PR DESCRIPTION
This PR adds new functionality to allow RTL text in react-mentions. Under normal circumstances, you can achieve this via CSS `direction: rtl`, however, the problem with that is that you need to know which direction is going to be used up front or you need to detect it from the textarea value on change. However, HTML supports `dir="auto"` as attribute on any element that enabled auto detection by the browser.

In our use case, we have a textarea where we expect RTL and LTR text to appear at the same time - you first add the text in your RTL language and then you add Engligh below it. This means we need text direction per paragraph of text. We take this approach everywhere but now we would like to allow mentioning, so we are looking into react-mentions for the functionality.

I called the prop unstable, because I don't thinks it complete and it needs to be improved, but I need help with this by someone who knows the library a bit more. One problem will be a `selection` that is hard to achieve with multiple wrapping divs.

This also solves #469
