### PR TITLE
forwardRef used in defaultStyle to pass ref in MentionInput component

### DIFF
--- a/src/utils/defaultStyle.js
+++ b/src/utils/defaultStyle.js
@@ -22,7 +22,9 @@ function createDefaultStyle(defaultStyle, getModifiers) {
       ComponentToWrap.displayName || ComponentToWrap.name || 'Component'
     DefaultStyleEnhancer.displayName = `defaultStyle(${displayName})`
 
-    return DefaultStyleEnhancer
+    return React.forwardRef((props, ref) => {
+      return DefaultStyleEnhancer({...props, ref})
+    })
   }
 
   return enhance


### PR DESCRIPTION
Fixes [#411](https://github.com/signavio/react-mentions/issues/411)


What did you change (functionally and technically)?
As MentionInput is wrapped by defaultStyle wrapper ref was not getting set. So In defaultStyle file under utils directory, i have used forwardRef to pass my ref to MentionInput component so that anyone can use MentionInput ref in their parent component. 

Use Case 
Recently i had a requirement in which after writing some query if there is only 1 suggestion and user enters space then that mention should get selected. To achieve this i checked there is no way to send custom key props in the react mention and i don't want to write `selectFocused` function code which covers all the use cases. So i want to use it through ref but due to the issue mentioned in #411. I was not able to do it

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code?
* No
* Does the code comply to our code conventions?
* Yes
* Does the PR resolve the whole issue?
* Yes

**Additional review hints** (remove this list before you submit the PR)
* Besides the code review, what should the reviewer test?
* Are there any edge cases?
* No
* Do you have any test files or test set-up?
* No
* Could your changes cause side effects elsewhere in the code base?
* No
