### PR TITLE
fix: scroll issue in disabled mode

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -194,6 +194,7 @@ class MentionsInput extends React.Component {
       ...style('input'),
 
       value: this.getPlainText(),
+      onScroll: this.updateHighlighterScroll,
 
       ...(!readOnly &&
         !disabled && {
@@ -203,7 +204,6 @@ class MentionsInput extends React.Component {
           onBlur: this.handleBlur,
           onCompositionStart: this.handleCompositionStart,
           onCompositionEnd: this.handleCompositionEnd,
-          onScroll: this.updateHighlighterScroll,
         }),
 
       ...(this.isOpened() && {


### PR DESCRIPTION
Fixes #501 

What did you change (functionally and technically)?

In the current implementation, the highlighted text position stays fixed when scrolled in a disabled state. Added a fix for the same.
