### PR TITLE
Properly position cursor after pasting content

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -3,6 +3,7 @@ import {
   applyChangeToValue,
   countSuggestions,
   escapeRegex,
+  findFirstDiffPos,
   findStartOfMentionInPlainText,
   getEndOfLastMention,
   getMentions,
@@ -366,15 +367,22 @@ class MentionsInput extends React.Component {
 
     const pastedMentions = event.clipboardData.getData('text/react-mentions')
     const pastedData = event.clipboardData.getData('text/plain')
+    const pasted = pastedMentions || pastedData
 
     const newValue = spliceString(
       value,
       markupStartIndex,
       markupEndIndex,
-      pastedMentions || pastedData
+      pasted
     ).replace(/\r/g, '')
 
     const newPlainTextValue = getPlainText(newValue, config)
+
+    // Calculate the new selection position.
+    const prevValue = getPlainText(value, config)
+    const startPos = findFirstDiffPos(prevValue, newPlainTextValue)
+    const nextLength = getPlainText(pasted, config).length
+    const nextPos = startPos + nextLength
 
     const eventMock = { target: { ...event.target, value: newValue } }
 
@@ -384,6 +392,8 @@ class MentionsInput extends React.Component {
       newPlainTextValue,
       getMentions(newValue, config)
     )
+
+    this.setSelection(nextPos, nextPos)
   }
 
   saveSelectionToClipboard(event) {

--- a/src/utils/findFirstDiffPos.js
+++ b/src/utils/findFirstDiffPos.js
@@ -1,0 +1,13 @@
+const findFirstDiffPos = (a, b) => {
+  const shorterLength = Math.min(a.length, b.length)
+
+  for (var i = 0; i < shorterLength; i++) {
+    if (a[i] !== b[i]) return i
+  }
+
+  if (a.length !== b.length) return shorterLength
+
+  return -1
+}
+
+export default findFirstDiffPos

--- a/src/utils/findFirstDiffPos.spec.js
+++ b/src/utils/findFirstDiffPos.spec.js
@@ -1,0 +1,33 @@
+import findFirstDiffPos from './findFirstDiffPos'
+
+describe('#findFirstDiffPos', () => {
+  it('should return -1 if the strings are equal', () => {
+    const result = findFirstDiffPos('Hello world', 'Hello world')
+    expect(result).toBe(-1)
+  })
+
+  const mapping = [
+    {
+      a: 'Hello world',
+      b: 'Hell0 world',
+      expected: 4,
+    },
+    {
+      a: 'Hello world',
+      b: 'He world',
+      expected: 2,
+    },
+    {
+      a: 'Hell0 world',
+      b: 'Hello word',
+      expected: 4,
+    },
+  ]
+
+  it('should return the correct position if the strings differs', () => {
+    mapping.forEach(({ a, b, expected }) => {
+      const result = findFirstDiffPos(a, b)
+      expect(result).toBe(expected)
+    })
+  })
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,9 +1,8 @@
 export { default as escapeRegex } from './escapeRegex'
 export { default as getPlainText } from './getPlainText'
 export { default as applyChangeToValue } from './applyChangeToValue'
-export {
-  default as findStartOfMentionInPlainText,
-} from './findStartOfMentionInPlainText'
+export { default as findFirstDiffPos } from './findFirstDiffPos'
+export { default as findStartOfMentionInPlainText } from './findStartOfMentionInPlainText'
 export { default as getMentions } from './getMentions'
 export { default as getSuggestionHtmlId } from './getSuggestionHtmlId'
 export { default as countSuggestions } from './countSuggestions'


### PR DESCRIPTION
Fixes #375 

As described in the issue above, pasting content sets the cursor to the end of the textarea, instead of leaving it after the pasted content. This PR fixes that.

At the end of the `handlePaste` method the new position of the cursor is calculated and passed to the `setSelection` method.
