### PR TITLE
fix: forceSuggestionsAboveCursor when suggestionsPortalHost is not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | suggestionsPortalHost       | DOM Element                                             | undefined      | Render suggestions into the DOM in the supplied host element.                          |
 | inputRef                    | React ref                                               | undefined      | Accepts a React ref to forward to the underlying input element                         |
 | allowSuggestionsAboveCursor | boolean                                                 | false          | Renders the SuggestionList above the cursor if there is not enough space below         |
+| forceSuggestionsAboveCursor | boolean                                                 | false          | Forces the SuggestionList to be rendered above the cursor                              |
 | a11ySuggestionsListLabel    | string                                                  | `''`           | This label would be exposed to screen readers when suggestion popup appears            |
 
 Each data source is configured using a `Mention` component, which has the following props:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | --------------------------- | ------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------- |
 | value                       | string                                                  | `''`           | The value containing markup for mentions                                               |
 | onChange                    | function (event, newValue, newPlainTextValue, mentions) | empty function | A callback that is invoked when the user changes the value in the mentions input       |
+| onKeyDown                   | function (event)                                        | empty function | A callback that is invoked when the user presses a key in the mentions input           |
 | singleLine                  | boolean                                                 | `false`        | Renders a single line text input instead of a textarea, if set to `true`               |
 | onBlur                      | function (event, clickedSuggestion)                     | empty function | Passes `true` as second argument if the blur was caused by a mousedown on a suggestion |
 | allowSpaceInQuery           | boolean                                                 | false          | Keep suggestions open even if the user separates keywords with spaces.                 |

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -739,13 +739,14 @@ class MentionsInput extends React.Component {
       // move the list up above the caret if it's getting cut off by the bottom of the window, provided that the list height
       // is small enough to NOT cover up the caret
       if (
-        allowSuggestionsAboveCursor &&
+        (allowSuggestionsAboveCursor &&
         viewportRelative.top -
           highlighter.scrollTop +
           suggestions.offsetHeight >
           viewportHeight &&
         suggestions.offsetHeight <
-          caretOffsetParentRect.top - caretHeight - highlighter.scrollTop
+          caretOffsetParentRect.top - caretHeight - highlighter.scrollTop) ||
+        forceSuggestionsAboveCursor
       ) {
         position.top = top - suggestions.offsetHeight - caretHeight
       } else {


### PR DESCRIPTION
Fix forceSuggestionsAboveCursor when suggestionsPortalHost is not being used. Mistake in https://github.com/signavio/react-mentions/pull/449.

Here's a quick repro: https://codesandbox.io/s/react-mentions-forcesuggestionsabovecursor-bug-bq1x0?file=/src/App.js

Resize your browser window so that the suggestions do not fit above the input field to trigger the bug.

Let me know if you need anything else for this fix. Thanks!

By the way, the links on [the releases page](https://github.com/signavio/react-mentions/releases) are not clickable. They render like this: `http://git+https/github.com/signavio/react-mentions/issues/492`. Is this intentional?