### PR TITLE
Add fictional character names in Asian languages for testing.

### DIFF
--- a/demo/src/examples/Examples.js
+++ b/demo/src/examples/Examples.js
@@ -19,6 +19,30 @@ const users = [
     display: 'Walter White',
   },
   {
+    id: 'pipilu',
+    display: '皮皮鲁',
+  },
+  {
+    id: 'luxixi',
+    display: '鲁西西',
+  },
+  {
+    id: 'satoshi1',
+    display: '中本聪',
+  },
+  {
+    id: 'satoshi2',
+    display: 'サトシ・ナカモト',
+  },
+  {
+    id: 'nobi',
+    display: '野比のび太',
+  },
+  {
+    id: 'sung',
+    display: '성덕선',
+  },
+  {
     id: 'jesse',
     display: 'Jesse Pinkman',
   },


### PR DESCRIPTION
I'm working on several IME related bugs including https://github.com/signavio/react-mentions/issues/164

This pull request is a preparation for a proper fix.

Could you merge this one first and get it deployed to https://react-mentions.vercel.app/ so our users can test it with different languages?

Thanks!