### PR TITLE
fix positioning for overlay near the right side of a textarea/input

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -263,7 +263,7 @@ class MentionsInput extends React.Component {
       return null
     }
 
-    const { position, left, top } = this.state.suggestionsPosition
+    const { position, left, top, right } = this.state.suggestionsPosition
 
     const suggestionsNode = (
       <SuggestionsOverlay
@@ -272,6 +272,7 @@ class MentionsInput extends React.Component {
         position={position}
         left={left}
         top={top}
+        right={right}
         focusIndex={this.state.focusIndex}
         scrollFocusedIntoView={this.state.scrollFocusedIntoView}
         containerRef={this.setSuggestionsElement}

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -15,6 +15,7 @@ class SuggestionsOverlay extends Component {
     focusIndex: PropTypes.number,
     position: PropTypes.string,
     left: PropTypes.number,
+    right: PropTypes.number,
     top: PropTypes.number,
     scrollFocusedIntoView: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -76,6 +77,7 @@ class SuggestionsOverlay extends Component {
       containerRef,
       position,
       left,
+      right,
       top,
     } = this.props
 
@@ -86,7 +88,10 @@ class SuggestionsOverlay extends Component {
 
     return (
       <div
-        {...inline({ position: position || 'absolute', left, top }, style)}
+        {...inline(
+          { position: position || 'absolute', left, right, top },
+          style
+        )}
         onMouseDown={onMouseDown}
         ref={containerRef}
       >


### PR DESCRIPTION
Fixes #556

## Background

What did you change (functionally and technically)?

I forwarded the `right` calculation to the `SuggestionsOverlay`. It's calculated already in `updateSuggestionsPosition`

```
      // guard for mentions suggestions list clipped by right edge of window
      if (left + suggestions.offsetWidth > this.containerElement.offsetWidth) {
        position.right = 0
```

When upgrading from 3.3.2 to 4.0.0 the `style` was replaced explicitly by `left` & `top` which resulted in this regression. See here https://github.com/signavio/react-mentions/compare/v3.3.2...v4.0.1#diff-00403e8131ecb98542c8244e62a5d7da189e273b086d554fa319d4403a7844fcL62-R85

## Outcome

<img width="333" alt="Screenshot 2022-04-11 at 17 05 59" src="https://user-images.githubusercontent.com/223045/162771542-e08f2bda-ba2a-463a-ac92-fdcbe3cfc4fd.png">

