### PR TITLE
fix: Take newly typed characters into account when a mention is deleted

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -533,7 +533,8 @@ class MentionsInput extends React.Component {
       this.state.selectionEnd > startOfMention
     ) {
       // only if a deletion has taken place
-      selectionStart = startOfMention
+      selectionStart =
+        startOfMention + (ev.nativeEvent.data ? ev.nativeEvent.data.length : 0)
       selectionEnd = selectionStart
       setSelectionAfterMentionChange = true
     }


### PR DESCRIPTION
Fixes #564

What did you change (functionally and technically)?
See the bug report. When highlighting a mention and typing a character, the cursor is now placed at the correct position.
