### PR TITLE
Make the auto scroll code run again

### DIFF
--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -50,7 +50,7 @@ function SuggestionsOverlay({
     } else if (bottom > ulElement.offsetHeight) {
       ulElement.scrollTop = bottom - ulElement.offsetHeight
     }
-  }, [])
+  }, [focusIndex])
 
   const renderSuggestions = () => {
     const suggestionsToRender = Object.values(suggestions).reduce(


### PR DESCRIPTION
`<SuggestionsOverlay>` was converted to hooks and the code which handles scrolling to the (keyboard) selected suggestion item was moved from `componentDidUpdate` to a `useEffect` with an empty dependency array causing it to run only on mount instead of on every state change.

Removing the dependency array completely would bring back the original behavior but running just when `focusIndex` is often enough, so that has now been added to the (previously empty) dependency array.