### PR TITLE
applyChangeToValue handle null

### DIFF
--- a/src/utils/applyChangeToValue.js
+++ b/src/utils/applyChangeToValue.js
@@ -13,11 +13,11 @@ const applyChangeToValue = (
   let oldPlainTextValue = getPlainText(value, config)
 
   let lengthDelta = oldPlainTextValue.length - plainTextValue.length
-  if (selectionStartBefore === 'undefined') {
+  if (selectionStartBefore === null) {
     selectionStartBefore = selectionEndAfter + lengthDelta
   }
 
-  if (selectionEndBefore === 'undefined') {
+  if (selectionEndBefore === null) {
     selectionEndBefore = selectionStartBefore
   }
 


### PR DESCRIPTION
The null state for these variables is `null` and not the _string_ `undefined`. This caused some crazy bugs when changing `el.value` when the input was not focused.