### PR TITLE
fix: fix scroll into view automatically

### DIFF
--- a/.changeset/silver-boats-build.md
+++ b/.changeset/silver-boats-build.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+fix scroll into view automatically

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -50,7 +50,7 @@ function SuggestionsOverlay({
     } else if (bottom > ulElement.offsetHeight) {
       ulElement.scrollTop = bottom - ulElement.offsetHeight
     }
-  }, [])
+  }, [focusIndex, scrollFocusedIntoView, ulElement])
 
   const renderSuggestions = () => {
     const suggestionsToRender = Object.values(suggestions).reduce(


### PR DESCRIPTION
Fixes [#663](https://github.com/signavio/react-mentions/issues/653)

What did you change (functionally and technically)?
It was found that this problem occurred when the suggestionOverlay was refactored into a hook. [see this commit](https://github.com/signavio/react-mentions/commit/834240e5d4f17e0a9a0e63757dd4e72977330fa6)
Originally, the scroll position would be updated in componentDidUpdate, but in the hook version, it only does this in the initial effect.

so I fix effect's dependency to ensure scroll can be updated in correct time.
