### PR TITLE
fix: selection should be correctly set after pasting text

### DIFF
--- a/.changeset/sharp-toys-jam.md
+++ b/.changeset/sharp-toys-jam.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+Fix cursor jumping to the end of the textfield when pasting and using React 18

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -136,6 +136,8 @@ class MentionsInput extends React.Component {
 
       caretPosition: null,
       suggestionsPosition: {},
+
+      setSelectionAfterHandlePaste: false,
     }
   }
 
@@ -158,6 +160,10 @@ class MentionsInput extends React.Component {
     // the cursor to jump to the end
     if (this.state.setSelectionAfterMentionChange) {
       this.setState({ setSelectionAfterMentionChange: false })
+      this.setSelection(this.state.selectionStart, this.state.selectionEnd)
+    }
+    if (this.state.setSelectionAfterHandlePaste) {
+      this.setState({ setSelectionAfterHandlePaste: false })
       this.setSelection(this.state.selectionStart, this.state.selectionEnd)
     }
   }
@@ -398,7 +404,11 @@ class MentionsInput extends React.Component {
     const nextPos =
       (startOfMention || selectionStart) +
       getPlainText(pastedMentions || pastedData, config).length
-    this.setSelection(nextPos, nextPos)
+    this.setState({
+      selectionStart: nextPos,
+      selectionEnd: nextPos,
+      setSelectionAfterHandlePaste: true,
+    })
   }
 
   saveSelectionToClipboard(event) {


### PR DESCRIPTION
Fixes #658 

What did you change (functionally and technically)?

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code? ❌ (but there were none before)
* Does the code comply to our code conventions? ✅ (incl changeset)
* Does the PR resolve the whole issue?
  * Seems like the actual textarea update in React 18 happens a bit later and therefor we need to set it after the next render
