### PR TITLE
Fixed native undo/redo

### DIFF
--- a/.changeset/seven-kangaroos-remember.md
+++ b/.changeset/seven-kangaroos-remember.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+Fixed native undo/redo in case the input was not focused before the operation

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
-/.idea
 
 /reports
 /coverage
@@ -9,4 +8,4 @@
 
 npm-debug.log*
 
-*.log
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+/.idea
 
 /reports
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 
 npm-debug.log*
 
-
+*.log

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -515,13 +515,23 @@ class MentionsInput extends React.Component {
 
     let newPlainTextValue = ev.target.value
 
+    let selectionStartBefore = this.state.selectionStart;
+    if(selectionStartBefore == null) {
+      selectionStartBefore = ev.target.selectionStart;
+    }
+
+    let selectionEndBefore = this.state.selectionEnd;
+    if(selectionEndBefore == null) {
+      selectionEndBefore = ev.target.selectionEnd;
+    }
+
     // Derive the new value to set by applying the local change in the textarea's plain text
     let newValue = applyChangeToValue(
       value,
       newPlainTextValue,
       {
-        selectionStartBefore: this.state.selectionStart,
-        selectionEndBefore: this.state.selectionEnd,
+        selectionStartBefore,
+        selectionEndBefore,
         selectionEndAfter: ev.target.selectionEnd,
       },
       config


### PR DESCRIPTION
The fix for native undo/redo (only a plain text) in case the input was not focused before the operation.

Steps to reproduce:
- input any text to MentionInput
- focus something else
- press `ctrl`+`z`/`cmd`+`z`

![Screen Cast 2023-05-24 at 5 32 57 PM](https://github.com/signavio/react-mentions/assets/11138341/385937fb-1b8a-4434-9b40-542b5088c042)

Technically, the problem happens, because for such undo/redo operations `onChange` handler is called before `onSelect`, hence `this.state.selectionStart` and `this.state.selectionEnd` are `null` and the next value is calculated incorrectly, based on what there was before the operation and the value that should be set after one
