### PR TITLE
fix: fixes scroll into view in custom container elements

### DIFF
--- a/.changeset/smart-eyes-kiss.md
+++ b/.changeset/smart-eyes-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@lagroms/react-mentions": patch
+"@signavio/react-mentions": patch
 ---
 
 Custom container scrolling fixed, now works like other containers

--- a/.changeset/smart-eyes-kiss.md
+++ b/.changeset/smart-eyes-kiss.md
@@ -1,0 +1,5 @@
+---
+"@lagroms/react-mentions": patch
+---
+
+Custom container scrolling fixed, now works like other containers

--- a/src/SuggestionsOverlay.js
+++ b/src/SuggestionsOverlay.js
@@ -53,19 +53,29 @@ function SuggestionsOverlay({
   }, [focusIndex, scrollFocusedIntoView, ulElement])
 
   const renderSuggestions = () => {
-    const suggestionsToRender = Object.values(suggestions).reduce(
-      (accResults, { results, queryInfo }) => [
-        ...accResults,
-        ...results.map((result, index) =>
-          renderSuggestion(result, queryInfo, accResults.length + index)
-        ),
-      ],
-      []
+    const suggestionsToRender = (
+      <ul
+        ref={setUlElement}
+        id={id}
+        role="listbox"
+        aria-label={a11ySuggestionsListLabel}
+        {...style('list')}
+      >
+        {Object.values(suggestions).reduce(
+          (accResults, { results, queryInfo }) => [
+            ...accResults,
+            ...results.map((result, index) =>
+              renderSuggestion(result, queryInfo, accResults.length + index)
+            ),
+          ],
+          []
+        )}
+      </ul>
     )
 
     if (customSuggestionsContainer)
       return customSuggestionsContainer(suggestionsToRender)
-    else return suggestionsToRender
+    return suggestionsToRender
   }
 
   const renderSuggestion = (result, queryInfo, index) => {
@@ -125,15 +135,7 @@ function SuggestionsOverlay({
       onMouseDown={onMouseDown}
       ref={containerRef}
     >
-      <ul
-        ref={setUlElement}
-        id={id}
-        role="listbox"
-        aria-label={a11ySuggestionsListLabel}
-        {...style('list')}
-      >
-        {renderSuggestions()}
-      </ul>
+      {renderSuggestions()}
       {renderLoadingIndicator()}
     </div>
   )


### PR DESCRIPTION
Fixes issue: [674](https://github.com/signavio/react-mentions/issues/674)

What did you change (functionally and technically)?
When attempting to scroll through the custom container elements an error would occur. I found that the custom container was being rendered inside the unordered list instead of around it. Rearranged the elements

**Checklist** (remove this list before you submit the PR)
* Are there tests for the new code? No
* Does the code comply to our code conventions? Yes
* Does the PR resolve the whole issue? Yes

How to test:
- Add `maxHeight` and `overflowY: 'auto'` to the list styling in SuggestionsOverlay.js
- Run react-mentions and open on localhost
- Scroll down to the custom container element
- Pull up the suggestions list with the '@' button
- Try scrolling through the list with the `up` and `down` buttons
