### PR TITLE
Fixed package key for changesets

### DIFF
--- a/.changeset/smart-eyes-kiss.md
+++ b/.changeset/smart-eyes-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@signavio/react-mentions": patch
+"react-mentions": patch
 ---
 
 Custom container scrolling fixed, now works like other containers


### PR DESCRIPTION
accidentally put wrong package key into the changeset, now the release process does not work because it can not find the correct package 

[failing pipeline](https://github.com/signavio/react-mentions/actions/runs/5141064240/jobs/9256013946)

