### PR TITLE
Fix double-paste bug

### DIFF
--- a/.changeset/popular-ladybugs-jog.md
+++ b/.changeset/popular-ladybugs-jog.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+Fix double-paste bug

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -359,7 +359,7 @@ class MentionsInput extends React.Component {
       return
     }
 
-    // event.preventDefault()
+    event.preventDefault()
 
     const { selectionStart, selectionEnd } = this.state
     const { value, children } = this.props


### PR DESCRIPTION
Fixes bug introduced by [here](https://github.com/signavio/react-mentions/commit/3f40576fcf57580f7b49640585c5a19c4f79e30e#diff-b93f5486e33dabca047d7813cfda3b850e21823fdb3dae6ad48f6b2f7662ba8eL362) where content is pasted twice - you can view this behavior on https://react-mentions.vercel.app/