### PR TITLE
Remove default autoFocus from textarea

### DIFF
--- a/.changeset/healthy-ways-protect.md
+++ b/.changeset/healthy-ways-protect.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+Remove autofocus from textarea by default

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -247,7 +247,7 @@ class MentionsInput extends React.Component {
   }
 
   renderTextarea = (props) => {
-    return <textarea autoFocus ref={this.setInputRef} {...props} />
+    return <textarea ref={this.setInputRef} {...props} />
   }
 
   setInputRef = (el) => {


### PR DESCRIPTION
Hi team 👋 
After I upgraded to `4.4.8` I was experiencing some layout shifts when rendering the input as a `textarea` inside of a modal. This was caused by the `autoFocus` being turned on when `textarea` is rendered. `autoFocus` should be passed using props since this is not a default behavior. 
