### PR TITLE
fix: suggestions not showing while composing

### DIFF
--- a/.changeset/khaki-dryers-kneel.md
+++ b/.changeset/khaki-dryers-kneel.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+Fix suggestions not showing while composing

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -564,6 +564,10 @@ class MentionsInput extends React.Component {
 
     let mentions = getMentions(newValue, config)
 
+    if (ev.nativeEvent.isComposing && selectionStart === selectionEnd) {
+      this.updateMentionsQueries(this.inputElement.value, selectionStart)
+    }
+
     // Propagate change
     // let handleChange = this.getOnChange(this.props) || emptyFunction;
     let eventMock = { target: { value: newValue } }


### PR DESCRIPTION
Fixes suggestions not showing while composing issue

---

## ▶︎ Expected Behavior:
![Jun-20-2023 16-37-13](https://github.com/signavio/react-mentions/assets/30749436/5b31dc8f-1bae-4237-80f6-99841d625e04)

<br/>

## ▶︎ Actual Behavior:
![Jun-20-2023 17-17-08](https://github.com/signavio/react-mentions/assets/30749436/ededf597-ea5d-4ceb-ab6f-b3061c9bf365)

