### PR TITLE
Fix dropdown location

### DIFF
--- a/.changeset/silly-bears-ring.md
+++ b/.changeset/silly-bears-ring.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": patch
+---
+
+fix: dropdown position now appears in correct location when clicking around textbox

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -150,11 +150,7 @@ class MentionsInput extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    // Update position of suggestions unless this componentDidUpdate was
-    // triggered by an update to suggestionsPosition.
-    if (prevState.suggestionsPosition === this.state.suggestionsPosition) {
-      this.updateSuggestionsPosition()
-    }
+    this.updateSuggestionsPosition()
 
     // maintain selection in case a mention is added/removed causing
     // the cursor to jump to the end
@@ -517,14 +513,14 @@ class MentionsInput extends React.Component {
 
     let newPlainTextValue = ev.target.value
 
-    let selectionStartBefore = this.state.selectionStart;
-    if(selectionStartBefore == null) {
-      selectionStartBefore = ev.target.selectionStart;
+    let selectionStartBefore = this.state.selectionStart
+    if (selectionStartBefore == null) {
+      selectionStartBefore = ev.target.selectionStart
     }
 
-    let selectionEndBefore = this.state.selectionEnd;
-    if(selectionEndBefore == null) {
-      selectionEndBefore = ev.target.selectionEnd;
+    let selectionEndBefore = this.state.selectionEnd
+    if (selectionEndBefore == null) {
+      selectionEndBefore = ev.target.selectionEnd
     }
 
     // Derive the new value to set by applying the local change in the textarea's plain text


### PR DESCRIPTION
Fixes issue where dropdown will appear in previous caret position when clicking next to an @ symbol

What did you change (functionally and technically)?
- conditional statement that would cause the caret position not to update correctly removed

How to test:
- select a text box and type an `@` symbol
- click somewhere else in the text box to move the caret 
- click back on the `@` symbol
- Expected: Dropdown should appear by the `@` symbol
