### PR TITLE
Added useRawValueOnCopy prop

### DIFF
--- a/.changeset/fresh-pans-cough.md
+++ b/.changeset/fresh-pans-cough.md
@@ -1,0 +1,5 @@
+---
+"react-mentions": minor
+---
+
+Added useRawValueOnCopy prop

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | forceSuggestionsAboveCursor | boolean                                                 | false          | Forces the SuggestionList to be rendered above the cursor                              |
 | a11ySuggestionsListLabel    | string                                                  | `''`           | This label would be exposed to screen readers when suggestion popup appears            |
 | customSuggestionsContainer  | function(children)                                      | empty function | Allows customizing the container of the suggestions                                    |
+| useRawValueOnCopy           | boolean                                                 | false          | Returns the raw value (with tags) when copying the content                             |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -76,6 +76,7 @@ const propTypes = {
   forceSuggestionsAboveCursor: PropTypes.bool,
   ignoreAccents: PropTypes.bool,
   a11ySuggestionsListLabel: PropTypes.string,
+  useRawValueOnCopy: PropTypes.bool,
 
   value: PropTypes.string,
   onKeyDown: PropTypes.func,
@@ -110,6 +111,7 @@ class MentionsInput extends React.Component {
     ignoreAccents: false,
     singleLine: false,
     allowSuggestionsAboveCursor: false,
+    useRawValueOnCopy: false,
     onKeyDown: () => null,
     onSelect: () => null,
     onBlur: () => null,
@@ -428,14 +430,14 @@ class MentionsInput extends React.Component {
     )
     const markupEndIndex = mapPlainTextIndex(value, config, selectionEnd, 'END')
 
+    const textValue = event.target.value.slice(selectionStart, selectionEnd)
+    const rawValue = value.slice(markupStartIndex, markupEndIndex)
+
     event.clipboardData.setData(
       'text/plain',
-      event.target.value.slice(selectionStart, selectionEnd)
+      this.props.useRawValueOnCopy ? rawValue : textValue
     )
-    event.clipboardData.setData(
-      'text/react-mentions',
-      value.slice(markupStartIndex, markupEndIndex)
-    )
+    event.clipboardData.setData('text/react-mentions', rawValue)
   }
 
   supportsClipboardActions(event) {


### PR DESCRIPTION
Added useRawValueOnCopy prop

What did you change (functionally and technically)? 

Added a new prop: `useRawValueOnCopy`

The default value is `false` and it won't change any behavior. 

When that is set to `true`, when performing a copy/cut, instead of copying the content without tags to the clipboard, it will copy the raw content with tags. So for example, if I have the following:

```
Hi %{name}, how are you?
```

That is displayed like:

```
Hi Name, how are you?
```

The copied content in the clipboard with the prop on will be: `Hi %{name}, how are you?`. The default behavior is to copy `Hi Name, how are you?` to the clipboard. 

This is a real use case need, where users might copy the text content and send to others for review, or paste into translation tools. When having the tags around the content, translation tools will ignore it and also, people reviewing or changing the content outside the app will be aware of the tags. 

Any feedback is appreciated :) Thanks for the awesome repo. If this goes live, I can update the DefinitelyTyped repo as well. 

