### PR TITLE
Added support of adding mentions when using package in the shadow dom

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -145,6 +145,7 @@ class MentionsInput extends React.Component {
     document.addEventListener('copy', this.handleCopy)
     document.addEventListener('cut', this.handleCut)
     document.addEventListener('paste', this.handlePaste)
+    window.addEventListener('trigger-shadow-root-input-onSelect', this.handleSelect)
 
     this.updateSuggestionsPosition()
   }
@@ -172,6 +173,7 @@ class MentionsInput extends React.Component {
     document.removeEventListener('copy', this.handleCopy)
     document.removeEventListener('cut', this.handleCut)
     document.removeEventListener('paste', this.handlePaste)
+    window.addEventListener('trigger-shadow-root-input-onSelect', this.handleSelect)
   }
 
   render() {
@@ -586,7 +588,11 @@ class MentionsInput extends React.Component {
   }
 
   // Handle input element's select event
-  handleSelect = (ev) => {
+  handleSelect = (event) => {
+    // from shadow dom fire custom event and pass event to handleSelect via event.detail.event
+    // in shadow dom onSelect event does not work
+    // https://it.javascript.info/shadow-dom-events
+    const ev = event.detail ? event.detail.event : event
     // keep track of selection range / caret position
     this.setState({
       selectionStart: ev.target.selectionStart,


### PR DESCRIPTION
Fixes #OnSelect event for shadow dom

What I have changed?

**onSelect** event
* Events only cross shadow DOM boundaries if their composed flag is set to true.
* Some built-in events that have composed: false: Such select
* So when I used this package in shadow root it didn't work.
* The solution is add custom events in my microfrontend and trigger event when it is necessary passing events via detail prop
* For this I have added listeners and called onSelect.
